### PR TITLE
release: v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,71 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] - 2025-01-27
+
+### Added
+
+- **Catalyst Center D2D Testing Support** ([#6](https://github.com/netascode/nac-test-pyats-common/pull/6))
+  - `CatalystCenterDeviceResolver` for D2D SSH testing via `catalyst_center.inventory.devices[]` schema
+  - Device state validation (skips devices in INIT/PNP states)
+  - Comprehensive unit tests for device resolver and auth modules
+
+- **SD-WAN Cascading Management IP Variable Lookup** ([#3](https://github.com/netascode/nac-test-pyats-common/pull/3))
+  - Router-level `management_ip_variable` override support
+  - Falls back to global `sdwan.management_ip_variable` when not set at router level
+  - `skipped_devices` tracking replaces deprecated `test_inventory`
+  - Exposed `_last_resolver` for accessing skip reasons
+
+- **BaseDeviceResolver Improvements** ([#9](https://github.com/netascode/nac-test-pyats-common/pull/9))
+  - `extract_device_id()` is now optional with sensible default (delegates to `extract_hostname()`)
+  - Added IP address validation after CIDR stripping using Python's `ipaddress` module
+  - Descriptive error messages for malformed IP addresses
+
+### Changed
+
+- Removed redundant `extract_device_id()` from `CatalystCenterDeviceResolver` (now uses inherited default)
+
+### Fixed
+
+- Dependabot configured to ignore `nac-test` until beta branch merges ([#9](https://github.com/netascode/nac-test-pyats-common/pull/9))
+
+## [0.1.1] - 2025-01-24
+
+### Changed
+
+- Version bump only (no functional changes)
+
+## [0.1.0] - 2025-01-23
+
+### Added
+
+- **Core Package Structure**
+  - Type-safe Python package with py.typed marker
+  - Pre-commit hooks and GitHub Actions CI/CD
+
+- **ACI/APIC Architecture Adapter**
+  - `APICAuth` for APIC controller authentication
+  - `APICTestBase` base class for APIC API tests
+
+- **SD-WAN Architecture Adapter**
+  - `SDWANManagerAuth` for SD-WAN Manager authentication
+  - `SDWANManagerTestBase` for controller API tests
+  - `SDWANTestBase` for device tests
+  - `SDWANDeviceResolver` for D2D testing via `sdwan.sites[].routers[]` schema
+
+- **Base Device Resolver**
+  - Template Method pattern for architecture-specific device resolution
+  - Credential injection from environment variables
+  - CIDR notation handling for IP addresses
+
+- **IOS-XE Integration**
+  - `IOSXETestBase` with architecture auto-detection
+  - Resolver registry for dynamic architecture selection
+
+[0.2.0]: https://github.com/netascode/nac-test-pyats-common/compare/v0.1.1...v0.2.0
+[0.1.1]: https://github.com/netascode/nac-test-pyats-common/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/netascode/nac-test-pyats-common/releases/tag/v0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nac-test-pyats-common"
-version = "0.1.1"
+version = "0.2.0"
 description = "Architecture adapters for Network as Code (NaC) PyATS testing - auth classes, test base classes, and device resolvers"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -784,7 +784,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1953,7 +1953,7 @@ wheels = [
 
 [[package]]
 name = "nac-test-pyats-common"
-version = "0.1.1"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- Bump version from 0.1.1 to 0.2.0
- Add CHANGELOG.md documenting all releases

## What's in 0.2.0

- Catalyst Center D2D testing support (#6)
- SD-WAN cascading `management_ip_variable` lookup (#3)
- BaseDeviceResolver improvements: optional `extract_device_id()`, IP validation (#9)

## After Merge

Create and push the tag:
```bash
git tag v0.2.0
git push origin v0.2.0
```