### PR TITLE
fix(aci): align env var names with nac-test controller registry

### DIFF
--- a/src/nac_test_pyats_common/aci/auth.py
+++ b/src/nac_test_pyats_common/aci/auth.py
@@ -239,10 +239,10 @@ except Exception as e:
         to efficiently manage token lifecycle.
 
         Environment Variables Required:
-            APIC_URL: Base URL of the APIC controller
-            APIC_USERNAME: APIC username for authentication
-            APIC_PASSWORD: APIC password for authentication
-            APIC_INSECURE: Optional. Set to "True" to disable SSL verification
+            ACI_URL: Base URL of the APIC controller
+            ACI_USERNAME: APIC username for authentication
+            ACI_PASSWORD: APIC password for authentication
+            ACI_INSECURE: Optional. Set to "True" to disable SSL verification
                 (default: True for backward compatibility)
 
         Returns:
@@ -251,10 +251,10 @@ except Exception as e:
         Raises:
             ValueError: If required environment variables are not set.
         """
-        url = os.environ.get("APIC_URL")
-        username = os.environ.get("APIC_USERNAME")
-        password = os.environ.get("APIC_PASSWORD")
-        insecure = os.environ.get("APIC_INSECURE", "True").lower() in (
+        url = os.environ.get("ACI_URL")
+        username = os.environ.get("ACI_USERNAME")
+        password = os.environ.get("ACI_PASSWORD")
+        insecure = os.environ.get("ACI_INSECURE", "True").lower() in (
             "true",
             "1",
             "yes",
@@ -263,11 +263,11 @@ except Exception as e:
         # Validate environment variables and collect missing ones
         missing_vars: list[str] = []
         if not url:
-            missing_vars.append("APIC_URL")
+            missing_vars.append("ACI_URL")
         if not username:
-            missing_vars.append("APIC_USERNAME")
+            missing_vars.append("ACI_USERNAME")
         if not password:
-            missing_vars.append("APIC_PASSWORD")
+            missing_vars.append("ACI_PASSWORD")
 
         if missing_vars:
             raise ValueError(

--- a/tests/unit/aci/test_auth.py
+++ b/tests/unit/aci/test_auth.py
@@ -39,38 +39,38 @@ class TestGetAuthEnvironmentValidation:
     """Test environment variable validation."""
 
     def test_get_auth_missing_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Test error when APIC_URL is missing."""
-        monkeypatch.setenv("APIC_USERNAME", "admin")
-        monkeypatch.setenv("APIC_PASSWORD", "password123")
-        # APIC_URL not set
+        """Test error when ACI_URL is missing."""
+        monkeypatch.setenv("ACI_USERNAME", "admin")
+        monkeypatch.setenv("ACI_PASSWORD", "password123")
+        # ACI_URL not set
 
         with pytest.raises(ValueError) as exc_info:
             APICAuth.get_auth()
 
-        assert "APIC_URL" in str(exc_info.value)
+        assert "ACI_URL" in str(exc_info.value)
         assert "Missing required environment variables" in str(exc_info.value)
 
     def test_get_auth_missing_username(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Test error when APIC_USERNAME is missing."""
-        monkeypatch.setenv("APIC_URL", "https://apic.example.com")
-        monkeypatch.setenv("APIC_PASSWORD", "password123")
-        # APIC_USERNAME not set
+        """Test error when ACI_USERNAME is missing."""
+        monkeypatch.setenv("ACI_URL", "https://apic.example.com")
+        monkeypatch.setenv("ACI_PASSWORD", "password123")
+        # ACI_USERNAME not set
 
         with pytest.raises(ValueError) as exc_info:
             APICAuth.get_auth()
 
-        assert "APIC_USERNAME" in str(exc_info.value)
+        assert "ACI_USERNAME" in str(exc_info.value)
 
     def test_get_auth_missing_password(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Test error when APIC_PASSWORD is missing."""
-        monkeypatch.setenv("APIC_URL", "https://apic.example.com")
-        monkeypatch.setenv("APIC_USERNAME", "admin")
-        # APIC_PASSWORD not set
+        """Test error when ACI_PASSWORD is missing."""
+        monkeypatch.setenv("ACI_URL", "https://apic.example.com")
+        monkeypatch.setenv("ACI_USERNAME", "admin")
+        # ACI_PASSWORD not set
 
         with pytest.raises(ValueError) as exc_info:
             APICAuth.get_auth()
 
-        assert "APIC_PASSWORD" in str(exc_info.value)
+        assert "ACI_PASSWORD" in str(exc_info.value)
 
     def test_get_auth_multiple_missing_vars(
         self, monkeypatch: pytest.MonkeyPatch
@@ -82,9 +82,9 @@ class TestGetAuthEnvironmentValidation:
             APICAuth.get_auth()
 
         error_msg = str(exc_info.value)
-        assert "APIC_URL" in error_msg
-        assert "APIC_USERNAME" in error_msg
-        assert "APIC_PASSWORD" in error_msg
+        assert "ACI_URL" in error_msg
+        assert "ACI_USERNAME" in error_msg
+        assert "ACI_PASSWORD" in error_msg
 
 
 class TestGetAuthUrlNormalization:
@@ -95,9 +95,9 @@ class TestGetAuthUrlNormalization:
         self, mock_get_token: MagicMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test that trailing slash is removed from URL."""
-        monkeypatch.setenv("APIC_URL", "https://apic.example.com/")
-        monkeypatch.setenv("APIC_USERNAME", "admin")
-        monkeypatch.setenv("APIC_PASSWORD", "password123")
+        monkeypatch.setenv("ACI_URL", "https://apic.example.com/")
+        monkeypatch.setenv("ACI_USERNAME", "admin")
+        monkeypatch.setenv("ACI_PASSWORD", "password123")
 
         mock_get_token.return_value = "test-token"
 
@@ -109,17 +109,17 @@ class TestGetAuthUrlNormalization:
 
 
 class TestGetAuthInsecureFlag:
-    """Test APIC_INSECURE environment variable handling."""
+    """Test ACI_INSECURE environment variable handling."""
 
     @patch("nac_test_pyats_common.aci.auth.APICAuth.get_token")
     def test_get_auth_insecure_default_true(
         self, mock_get_token: MagicMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Test that APIC_INSECURE defaults to True (verify_ssl=False)."""
-        monkeypatch.setenv("APIC_URL", "https://apic.example.com")
-        monkeypatch.setenv("APIC_USERNAME", "admin")
-        monkeypatch.setenv("APIC_PASSWORD", "password123")
-        # APIC_INSECURE not set - should default to True
+        """Test that ACI_INSECURE defaults to True (verify_ssl=False)."""
+        monkeypatch.setenv("ACI_URL", "https://apic.example.com")
+        monkeypatch.setenv("ACI_USERNAME", "admin")
+        monkeypatch.setenv("ACI_PASSWORD", "password123")
+        # ACI_INSECURE not set - should default to True
 
         mock_get_token.return_value = "test-token"
 
@@ -133,11 +133,11 @@ class TestGetAuthInsecureFlag:
     def test_get_auth_insecure_false_enables_ssl(
         self, mock_get_token: MagicMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Test that APIC_INSECURE=False enables SSL verification."""
-        monkeypatch.setenv("APIC_URL", "https://apic.example.com")
-        monkeypatch.setenv("APIC_USERNAME", "admin")
-        monkeypatch.setenv("APIC_PASSWORD", "password123")
-        monkeypatch.setenv("APIC_INSECURE", "False")
+        """Test that ACI_INSECURE=False enables SSL verification."""
+        monkeypatch.setenv("ACI_URL", "https://apic.example.com")
+        monkeypatch.setenv("ACI_USERNAME", "admin")
+        monkeypatch.setenv("ACI_PASSWORD", "password123")
+        monkeypatch.setenv("ACI_INSECURE", "False")
 
         mock_get_token.return_value = "test-token"
 
@@ -150,11 +150,11 @@ class TestGetAuthInsecureFlag:
     def test_get_auth_insecure_zero_enables_ssl(
         self, mock_get_token: MagicMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Test that APIC_INSECURE=0 enables SSL verification."""
-        monkeypatch.setenv("APIC_URL", "https://apic.example.com")
-        monkeypatch.setenv("APIC_USERNAME", "admin")
-        monkeypatch.setenv("APIC_PASSWORD", "password123")
-        monkeypatch.setenv("APIC_INSECURE", "0")
+        """Test that ACI_INSECURE=0 enables SSL verification."""
+        monkeypatch.setenv("ACI_URL", "https://apic.example.com")
+        monkeypatch.setenv("ACI_USERNAME", "admin")
+        monkeypatch.setenv("ACI_PASSWORD", "password123")
+        monkeypatch.setenv("ACI_INSECURE", "0")
 
         mock_get_token.return_value = "test-token"
 

--- a/uv.lock
+++ b/uv.lock
@@ -1956,7 +1956,7 @@ wheels = [
 
 [[package]]
 name = "nac-test-pyats-common"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "filelock" },


### PR DESCRIPTION
## Summary

- Renames `APIC_URL`, `APIC_USERNAME`, `APIC_PASSWORD`, `APIC_INSECURE` to `ACI_URL`, `ACI_USERNAME`, `ACI_PASSWORD`, `ACI_INSECURE` in `APICAuth.get_auth()`
- Updates docstrings and unit tests to match

## Why

`nac-test`'s `CONTROLLER_REGISTRY` and `detect_controller_type()` use architecture-based naming (`ACI_*`), but the ACI auth adapter was using controller-based naming (`APIC_*`). A fresh install of `nac-test-pyats-common` from `main` would read `APIC_URL` while `nac-test` tells users to set `ACI_URL` — causing a silent mismatch.

SDWAN and CC adapters already use consistent naming (`SDWAN_*`, `CC_*`) and are unaffected.

## Test plan

- [x] All existing `test_auth.py` tests updated and passing
- [x] Verified locally with editable install against live APIC