### PR TITLE
Add sdwan (20.18+) jwt token based auth support for pyats nac-test testcases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **SD-WAN Token Authentication Support** ([#TBD](https://github.com/netascode/nac-test-pyats-common/pull/TBD))
   - `SDWANManagerAuth.get_auth()` now consults `get_matched_credential_set()` from nac-test
     to determine authentication mechanism (token vs session)
-  - **Token auth** (SD-WAN Manager 20.18+): Uses `SDWAN_API_TOKEN` as Bearer token directly;
-    no subprocess login or session caching required
+  - **Token auth** (SD-WAN Manager 20.18+): Uses `SDWAN_API_TOKEN` as Bearer token;
+    CSRF token is extracted from the JWT payload and sent as `X-XSRF-TOKEN` header.
+    No subprocess login or session caching required
   - **Session auth** (legacy): Unchanged form-based login with JSESSIONID + XSRF token
-  - `SDWANManagerTestBase.get_sdwan_manager_client()` sets `Authorization: Bearer` header
-    for token auth, or `Cookie: JSESSIONID` + `X-XSRF-TOKEN` for session auth
-  - `get_auth()` return dict now includes `auth_method` key (`"token"` or `"session"`)
-  - 6 new unit tests covering token auth path, fallback behavior, and error cases
+  - `SDWANManagerTestBase.get_sdwan_manager_client()` sets `Authorization: Bearer` +
+    `X-XSRF-TOKEN` headers for token auth, or `Cookie: JSESSIONID` + `X-XSRF-TOKEN`
+    for session auth
+  - `get_auth()` return dict now includes `auth_method` key (`"token"` or `"session"`),
+    and for token auth also includes `csrf_token` extracted from the JWT payload
+  - 8 new unit tests covering token auth path, CSRF extraction, JWT validation,
+    fallback behavior, and error cases
 
 ## [0.2.0] - 2025-01-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **SD-WAN Token Authentication Support** ([#TBD](https://github.com/netascode/nac-test-pyats-common/pull/TBD))
+- **SD-WAN Token Authentication Support** ([#33](https://github.com/netascode/nac-test-pyats-common/pull/33))
   - `SDWANManagerAuth.get_auth()` now consults `get_matched_credential_set()` from nac-test
     to determine authentication mechanism (token vs session)
   - **Token auth** (SD-WAN Manager 20.18+): Uses `SDWAN_API_TOKEN` as Bearer token;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **SD-WAN Token Authentication Support** ([#TBD](https://github.com/netascode/nac-test-pyats-common/pull/TBD))
+  - `SDWANManagerAuth.get_auth()` now consults `get_matched_credential_set()` from nac-test
+    to determine authentication mechanism (token vs session)
+  - **Token auth** (SD-WAN Manager 20.18+): Uses `SDWAN_API_TOKEN` as Bearer token directly;
+    no subprocess login or session caching required
+  - **Session auth** (legacy): Unchanged form-based login with JSESSIONID + XSRF token
+  - `SDWANManagerTestBase.get_sdwan_manager_client()` sets `Authorization: Bearer` header
+    for token auth, or `Cookie: JSESSIONID` + `X-XSRF-TOKEN` for session auth
+  - `get_auth()` return dict now includes `auth_method` key (`"token"` or `"session"`)
+  - 6 new unit tests covering token auth path, fallback behavior, and error cases
+
 ## [0.2.0] - 2025-01-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **SD-WAN API Token Authentication (20.18+)**
+  - `SDWANManagerAuth` now supports JWT-based API token authentication via `SDWAN_API_TOKEN` environment variable
+  - When `SDWAN_API_TOKEN` is set, it takes priority over username/password session auth
+  - CSRF token is extracted from the JWT payload (`csrf` field) — no network call needed
+  - `SDWANManagerTestBase.get_sdwan_manager_client()` automatically uses Bearer authorization headers for token auth
+  - Unit tests for JWT decoding, CSRF extraction, and auth method priority
+
 ## [0.2.0] - 2025-01-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `SDWANManagerAuth` now supports JWT-based API token authentication via `SDWAN_API_TOKEN` environment variable
   - When `SDWAN_API_TOKEN` is set, it takes priority over username/password session auth
   - CSRF token is extracted from the JWT payload (`csrf` field) — no network call needed
+  - API token auth bypasses `AuthCache` — JWT decoding is stateless, avoiding stale-token issues
   - `SDWANManagerTestBase.get_sdwan_manager_client()` automatically uses Bearer authorization headers for token auth
-  - Unit tests for JWT decoding, CSRF extraction, and auth method priority
+  - Missing credentials error messages now suggest `SDWAN_API_TOKEN` as an alternative for SD-WAN 20.18+
+  - Unit tests for JWT decoding, CSRF extraction, error handling, and auth method priority
 
 ## [0.2.0] - 2025-01-27
 

--- a/README.md
+++ b/README.md
@@ -189,10 +189,20 @@ Each architecture requires specific environment variables for authentication:
 - `CC_INSECURE` - Skip SSL verification (optional, default: "True")
 
 ### SD-WAN
-- `VMANAGE_URL` - vManage URL
-- `VMANAGE_USERNAME` - Username
-- `VMANAGE_PASSWORD` - Password
-- `VMANAGE_INSECURE` - Skip SSL verification (optional, default: "True")
+
+**Session auth (username/password):**
+- `SDWAN_URL` - SD-WAN Manager URL
+- `SDWAN_USERNAME` - Username
+- `SDWAN_PASSWORD` - Password
+- `SDWAN_INSECURE` - Skip SSL verification (optional, default: "True")
+
+**Token auth (20.18+):**
+- `SDWAN_URL` - SD-WAN Manager URL
+- `SDWAN_API_TOKEN` - API token for Bearer authentication
+
+The auth method is determined automatically by nac-test's credential set detection.
+If `SDWAN_API_TOKEN` is set (and `SDWAN_URL`), token auth is used. Otherwise,
+username/password session auth is used.
 
 ### ACI
 - `APIC_URL` - APIC URL

--- a/README.md
+++ b/README.md
@@ -198,11 +198,12 @@ Each architecture requires specific environment variables for authentication:
 
 **Token auth (20.18+):**
 - `SDWAN_URL` - SD-WAN Manager URL
-- `SDWAN_API_TOKEN` - API token for Bearer authentication
+- `SDWAN_API_TOKEN` - API token (JWT) for Bearer authentication
 
 The auth method is determined automatically by nac-test's credential set detection.
-If `SDWAN_API_TOKEN` is set (and `SDWAN_URL`), token auth is used. Otherwise,
-username/password session auth is used.
+If `SDWAN_API_TOKEN` is set (and `SDWAN_URL`), token auth is used — the JWT payload
+is decoded to extract the CSRF token, which is sent as the `X-XSRF-TOKEN` header
+alongside `Authorization: Bearer`. Otherwise, username/password session auth is used.
 
 ### ACI
 - `APIC_URL` - APIC URL

--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ Each NAC architecture repository previously contained duplicated PyATS infrastru
   - `ACIDeviceResolver` - Device inventory from ACI data models
 
 - **SD-WAN**
-  - `VManageAuth` - vManage authentication with token-based sessions
-  - `VManageTestBase` - Base class for vManage API tests
-  - `SDWANSSHTestBase` - Base class for SD-WAN D2D/SSH tests
+  - `SDWANManagerAuth` - SDWAN Manager authentication (session auth + API token auth for 20.18+)
+  - `SDWANManagerTestBase` - Base class for SDWAN Manager API tests
+  - `SDWANTestBase` - Base class for SD-WAN D2D/SSH tests
   - `SDWANDeviceResolver` - Device inventory from sites.nac.yaml
 
 - **Catalyst Center**
@@ -189,10 +189,11 @@ Each architecture requires specific environment variables for authentication:
 - `CC_INSECURE` - Skip SSL verification (optional, default: "True")
 
 ### SD-WAN
-- `VMANAGE_URL` - vManage URL
-- `VMANAGE_USERNAME` - Username
-- `VMANAGE_PASSWORD` - Password
-- `VMANAGE_INSECURE` - Skip SSL verification (optional, default: "True")
+- `SDWAN_URL` - SDWAN Manager URL (required for all auth methods)
+- `SDWAN_API_TOKEN` - JWT API token for 20.18+ token-based auth (optional, takes priority over username/password)
+- `SDWAN_USERNAME` - Username (required for session auth)
+- `SDWAN_PASSWORD` - Password (required for session auth)
+- `SDWAN_INSECURE` - Skip SSL verification (optional, default: "True", session auth only)
 
 ### ACI
 - `APIC_URL` - APIC URL

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Each NAC architecture repository previously contained duplicated PyATS infrastru
 │       Layer 2: nac-test-pyats-common (Architecture Adapters)        │
 │                    DEPENDS ON nac-test                               │
 │                                                                      │
-│  • Architecture-specific authentication (APICAuth, VManageAuth)      │
+│  • Architecture-specific authentication (APICAuth, SDWANManagerAuth) │
 │  • Architecture-specific test base classes (APICTestBase, etc.)      │
 │  • Architecture-specific device resolvers (SDWANDeviceResolver)      │
 │                       │                                              │
@@ -141,7 +141,7 @@ Each architecture provides an authentication class that handles controller-speci
 
 ```python
 from nac_test_pyats_common.aci import APICAuth
-from nac_test_pyats_common.sdwan import VManageAuth
+from nac_test_pyats_common.sdwan import SDWANManagerAuth
 from nac_test_pyats_common.catc import CatalystCenterAuth
 
 # Authentication is handled automatically when using test base classes

--- a/dev-docs/PRD_AND_ARCHITECTURE.md
+++ b/dev-docs/PRD_AND_ARCHITECTURE.md
@@ -900,7 +900,8 @@ nac-test's controller detection. If the matched credential set has
 **Auth Flow (Token — 20.18+):**
 ```
 No network call required.
-Headers: Authorization: Bearer {SDWAN_API_TOKEN}
+JWT payload decoded to extract CSRF token.
+Headers: Authorization: Bearer {SDWAN_API_TOKEN}, X-XSRF-TOKEN: {csrf from JWT}
 ```
 
 **Auth Flow (Session — legacy):**
@@ -1093,8 +1094,9 @@ class SDWANManagerAuth:
 
     @classmethod
     def _get_token_auth(cls) -> dict[str, Any]:
-        """Token auth: reads SDWAN_API_TOKEN, returns immediately."""
-        # Returns {"auth_method": "token", "api_token": <value>}
+        """Token auth: reads SDWAN_API_TOKEN, decodes JWT for CSRF."""
+        # Decodes JWT payload to extract csrf field
+        # Returns {"auth_method": "token", "api_token": <value>, "csrf_token": <csrf>}
 
     @classmethod
     def _get_session_auth(cls) -> dict[str, Any]:

--- a/dev-docs/PRD_AND_ARCHITECTURE.md
+++ b/dev-docs/PRD_AND_ARCHITECTURE.md
@@ -218,9 +218,10 @@ class Test(IOSXETestBase):
 ```
 
 **Environment variable detection priority:**
-1. `SDWAN_URL` + `SDWAN_USERNAME` + `SDWAN_PASSWORD` → SD-WAN architecture
-2. `CC_URL` + `CC_USERNAME` + `CC_PASSWORD` → Catalyst Center architecture
-3. Neither set → Infer from data model structure (sdwan key, catalyst_center key, or devices key)
+1. `SDWAN_URL` + `SDWAN_API_TOKEN` → SD-WAN architecture (token auth, 20.18+)
+2. `SDWAN_URL` + `SDWAN_USERNAME` + `SDWAN_PASSWORD` → SD-WAN architecture (session auth)
+3. `CC_URL` + `CC_USERNAME` + `CC_PASSWORD` → Catalyst Center architecture
+4. Neither set → Infer from data model structure (sdwan key, catalyst_center key, or devices key)
 
 ### Choosing the Right Test Base
 
@@ -229,7 +230,7 @@ Use this decision table to select the appropriate base class:
 | Architecture | Test Type | Base Class | Credentials Needed |
 |-------------|-----------|------------|-------------------|
 | ACI/APIC | API | `APICTestBase` | APIC_URL, APIC_USERNAME, APIC_PASSWORD |
-| SD-WAN | API | `SDWANManagerTestBase` | SDWAN_URL, SDWAN_USERNAME, SDWAN_PASSWORD |
+| SD-WAN | API | `SDWANManagerTestBase` | SDWAN_URL + SDWAN_API_TOKEN (token) or SDWAN_URL + SDWAN_USERNAME + SDWAN_PASSWORD (session) |
 | SD-WAN | SSH/D2D | `SDWANTestBase` | SDWAN_* (for detection) + IOSXE_USERNAME, IOSXE_PASSWORD |
 | SD-WAN | SSH/D2D | `IOSXETestBase` | Same as SDWANTestBase (auto-detects) |
 | Catalyst Center | API | `CatalystCenterTestBase` | CC_URL, CC_USERNAME, CC_PASSWORD |
@@ -873,12 +874,16 @@ POST /api/aaaLogin.json
 **Purpose:** Test Cisco SD-WAN deployments via SDWAN Manager API and direct device SSH
 
 **Components:**
-- `SDWANManagerAuth`: Form-based login with JSESSIONID + XSRF token
+- `SDWANManagerAuth`: Dual-mode authentication (token or session-based)
 - `SDWANManagerTestBase`: Base class for SDWAN Manager API tests
 - `SDWANTestBase`: Base class for SSH/D2D tests to edge devices
 - `SDWANDeviceResolver`: Device inventory resolution from SD-WAN schema
 
-**Environment Variables (Controller):**
+**Environment Variables (Controller — Token Auth, 20.18+):**
+- `SDWAN_URL`: Base URL of SDWAN Manager
+- `SDWAN_API_TOKEN`: API token for Bearer authentication
+
+**Environment Variables (Controller — Session Auth, legacy):**
 - `SDWAN_URL`: Base URL of SDWAN Manager
 - `SDWAN_USERNAME`: SDWAN Manager username
 - `SDWAN_PASSWORD`: SDWAN Manager password
@@ -887,7 +892,18 @@ POST /api/aaaLogin.json
 - `IOSXE_USERNAME`: SSH username for edge devices
 - `IOSXE_PASSWORD`: SSH password for edge devices
 
-**Auth Flow:**
+**Auth Method Selection:**
+The auth mechanism is determined by `get_matched_credential_set("SDWAN")` from
+nac-test's controller detection. If the matched credential set has
+`auth_method="token"`, token auth is used; otherwise session auth is used.
+
+**Auth Flow (Token — 20.18+):**
+```
+No network call required.
+Headers: Authorization: Bearer {SDWAN_API_TOKEN}
+```
+
+**Auth Flow (Session — legacy):**
 ```
 POST /j_security_check (form data: j_username, j_password)
   → Response: JSESSIONID cookie
@@ -896,7 +912,7 @@ GET /dataservice/client/token (19.2+ only)
   → Headers: Cookie: JSESSIONID={id}, X-XSRF-TOKEN: {token}
 ```
 
-**Session Lifetime:** 1800 seconds (30 minutes)
+**Session Lifetime:** 1800 seconds (30 minutes, session auth only)
 
 ### Catalyst Center Adapter
 
@@ -1053,20 +1069,38 @@ class APICAuth:
 class SDWANManagerAuth:
     @staticmethod
     def _authenticate(url: str, username: str, password: str) -> tuple[dict, int]:
-        """Low-level: Direct SDWAN Manager authentication."""
+        """Low-level: Direct SDWAN Manager session authentication."""
         # POST to /j_security_check (form-based)
         # GET /dataservice/client/token (for XSRF)
         # Returns ({"jsessionid": ..., "xsrf_token": ...}, 1800)
 
     @classmethod
     def get_auth(cls) -> dict[str, Any]:
-        """High-level: Cached session retrieval (reads env vars)."""
-        # Reads SDWAN_URL, SDWAN_USERNAME, SDWAN_PASSWORD from env
-        return AuthCache.get_or_create(
-            controller_type="SDWAN_MANAGER",
-            url=url,
-            auth_func=auth_wrapper,
-        )
+        """High-level: Determines auth method and returns credentials.
+
+        Consults get_matched_credential_set("SDWAN") from nac-test to
+        determine which auth mechanism to use:
+        - auth_method="token" → _get_token_auth() (Bearer token)
+        - auth_method="session" → _get_session_auth() (JSESSIONID)
+        """
+        from nac_test.utils.controller import get_matched_credential_set
+        matched = get_matched_credential_set("SDWAN")
+        auth_method = matched.auth_method if matched else "session"
+
+        if auth_method == "token":
+            return cls._get_token_auth()
+        return cls._get_session_auth()
+
+    @classmethod
+    def _get_token_auth(cls) -> dict[str, Any]:
+        """Token auth: reads SDWAN_API_TOKEN, returns immediately."""
+        # Returns {"auth_method": "token", "api_token": <value>}
+
+    @classmethod
+    def _get_session_auth(cls) -> dict[str, Any]:
+        """Session auth: form login with caching via AuthCache."""
+        # Returns {"auth_method": "session", "jsessionid": ..., "xsrf_token": ...}
+        return {"auth_method": "session", **AuthCache.get_or_create(...)}
 ```
 
 ### CatalystCenterAuth Implementation
@@ -1396,7 +1430,8 @@ class StandaloneIOSXEResolver(BaseDeviceResolver):
 | Architecture | URL Variable | Username Variable | Password Variable | Other |
 |-------------|--------------|-------------------|-------------------|-------|
 | ACI (APIC) | `APIC_URL` | `APIC_USERNAME` | `APIC_PASSWORD` | |
-| SD-WAN | `SDWAN_URL` | `SDWAN_USERNAME` | `SDWAN_PASSWORD` | |
+| SD-WAN (token) | `SDWAN_URL` | — | — | `SDWAN_API_TOKEN` |
+| SD-WAN (session) | `SDWAN_URL` | `SDWAN_USERNAME` | `SDWAN_PASSWORD` | |
 | Catalyst Center | `CC_URL` | `CC_USERNAME` | `CC_PASSWORD` | `CC_INSECURE` |
 
 ### Device Credentials

--- a/dev-docs/PRD_AND_ARCHITECTURE.md
+++ b/dev-docs/PRD_AND_ARCHITECTURE.md
@@ -1042,89 +1042,50 @@ All authentication modules use subprocess-based HTTP execution to avoid macOS fo
 - `SubprocessAuthError`: Raised when authentication subprocess fails
 - Re-exported from each auth module for convenient import by callers
 
-### APICAuth Implementation
+### APICAuth Flow
 
-```python
-class APICAuth:
-    @staticmethod
-    def authenticate(url: str, username: str, password: str) -> tuple[str, int]:
-        """Low-level: Direct APIC authentication."""
-        # POST to /api/aaaLogin.json
-        # Returns (token, 600)
+```
+1. authenticate(url, username, password)
+   → POST /api/aaaLogin.json with credentials
+   → Return (token, ttl=600)
 
-    @classmethod
-    def get_token(cls, url: str, username: str, password: str) -> str:
-        """High-level: Cached token retrieval."""
-        return AuthCache.get_or_create_token(
-            controller_type="ACI",
-            url=url,
-            username=username,
-            password=password,
-            auth_func=cls.authenticate,
-        )
+2. get_token(url, username, password)
+   → Delegate to AuthCache.get_or_create_token(controller_type="ACI", auth_func=authenticate)
+   → Return cached or fresh token
 ```
 
-### SDWANManagerAuth Implementation
+### SDWANManagerAuth Flow
 
-```python
-class SDWANManagerAuth:
-    @staticmethod
-    def _authenticate(url: str, username: str, password: str) -> tuple[dict, int]:
-        """Low-level: Direct SDWAN Manager session authentication."""
-        # POST to /j_security_check (form-based)
-        # GET /dataservice/client/token (for XSRF)
-        # Returns ({"jsessionid": ..., "xsrf_token": ...}, 1800)
+```
+1. Determine auth method:
+   → Call get_matched_credential_set("SDWAN") from nac-test
+   → If matched.auth_method == "token" → use token auth
+   → Otherwise → use session auth
 
-    @classmethod
-    def get_auth(cls) -> dict[str, Any]:
-        """High-level: Determines auth method and returns credentials.
+2a. Token auth (_get_token_auth):
+    → Read SDWAN_API_TOKEN from env
+    → Decode JWT payload to extract CSRF token
+    → Return {auth_method: "token", api_token, csrf_token}
 
-        Consults get_matched_credential_set("SDWAN") from nac-test to
-        determine which auth mechanism to use:
-        - auth_method="token" → _get_token_auth() (Bearer token)
-        - auth_method="session" → _get_session_auth() (JSESSIONID)
-        """
-        from nac_test.utils.controller import get_matched_credential_set
-        matched = get_matched_credential_set("SDWAN")
-        auth_method = matched.auth_method if matched else "session"
-
-        if auth_method == "token":
-            return cls._get_token_auth()
-        return cls._get_session_auth()
-
-    @classmethod
-    def _get_token_auth(cls) -> dict[str, Any]:
-        """Token auth: reads SDWAN_API_TOKEN, decodes JWT for CSRF."""
-        # Decodes JWT payload to extract csrf field
-        # Returns {"auth_method": "token", "api_token": <value>, "csrf_token": <csrf>}
-
-    @classmethod
-    def _get_session_auth(cls) -> dict[str, Any]:
-        """Session auth: form login with caching via AuthCache."""
-        # Returns {"auth_method": "session", "jsessionid": ..., "xsrf_token": ...}
-        return {"auth_method": "session", **AuthCache.get_or_create(...)}
+2b. Session auth (_get_session_auth):
+    → POST /j_security_check (form-based login)
+    → GET /dataservice/client/token (XSRF token)
+    → Cache via AuthCache (ttl=1800)
+    → Return {auth_method: "session", jsessionid, xsrf_token}
 ```
 
-### CatalystCenterAuth Implementation
+### CatalystCenterAuth Flow
 
-```python
-class CatalystCenterAuth:
-    @classmethod
-    def _authenticate(cls, url: str, username: str, password: str, verify_ssl: bool) -> tuple[dict, int]:
-        """Low-level: Direct Catalyst Center authentication."""
-        # POST to /api/system/v1/auth/token (Basic Auth)
-        # Fallback to /dna/system/api/v1/auth/token for legacy
-        # Returns ({"token": ...}, 3600)
+```
+1. _authenticate(url, username, password, verify_ssl)
+   → POST /api/system/v1/auth/token (Basic Auth)
+   → Fallback to /dna/system/api/v1/auth/token for legacy
+   → Return ({token: ...}, ttl=3600)
 
-    @classmethod
-    def get_auth(cls) -> dict[str, Any]:
-        """High-level: Cached token retrieval (reads env vars)."""
-        # Reads CC_URL, CC_USERNAME, CC_PASSWORD, CC_INSECURE from env
-        return AuthCache.get_or_create(
-            controller_type="CC",
-            url=url,
-            auth_func=auth_wrapper,
-        )
+2. get_auth()
+   → Read CC_URL, CC_USERNAME, CC_PASSWORD, CC_INSECURE from env
+   → Delegate to AuthCache.get_or_create(controller_type="CC", auth_func=wrapper)
+   → Return cached or fresh token
 ```
 
 ---

--- a/src/nac_test_pyats_common/aci/auth.py
+++ b/src/nac_test_pyats_common/aci/auth.py
@@ -30,6 +30,8 @@ from nac_test.pyats_core.common.subprocess_auth import (
     execute_auth_subprocess,
 )
 
+from nac_test_pyats_common.common.env import require_env_vars
+
 # Default token lifetime for APIC authentication tokens in seconds
 # APIC tokens are typically valid for 10 minutes (600 seconds) by default
 APIC_TOKEN_LIFETIME_SECONDS: int = 600
@@ -251,37 +253,15 @@ except Exception as e:
         Raises:
             ValueError: If required environment variables are not set.
         """
-        url = os.environ.get("ACI_URL")
-        username = os.environ.get("ACI_USERNAME")
-        password = os.environ.get("ACI_PASSWORD")
+        env = require_env_vars("ACI_URL", "ACI_USERNAME", "ACI_PASSWORD")
+        url = env["ACI_URL"].rstrip("/")
+        username = env["ACI_USERNAME"]
+        password = env["ACI_PASSWORD"]
         insecure = os.environ.get("ACI_INSECURE", "True").lower() in (
             "true",
             "1",
             "yes",
         )
-
-        # Validate environment variables and collect missing ones
-        missing_vars: list[str] = []
-        if not url:
-            missing_vars.append("ACI_URL")
-        if not username:
-            missing_vars.append("ACI_USERNAME")
-        if not password:
-            missing_vars.append("ACI_PASSWORD")
-
-        if missing_vars:
-            raise ValueError(
-                f"Missing required environment variables: {', '.join(missing_vars)}"
-            )
-
-        # Type narrowing: url, username, password are guaranteed to be str
-        # We raised ValueError above if any were None/empty
-        assert url is not None
-        assert username is not None
-        assert password is not None
-
-        # Normalize URL by removing trailing slash
-        url = url.rstrip("/")
         verify_ssl = not insecure  # APIC_INSECURE=True means verify=False
 
         return cls.get_token(url, username, password, verify_ssl)

--- a/src/nac_test_pyats_common/catc/auth.py
+++ b/src/nac_test_pyats_common/catc/auth.py
@@ -31,6 +31,8 @@ from nac_test.pyats_core.common.subprocess_auth import (
     execute_auth_subprocess,
 )
 
+from nac_test_pyats_common.common.env import require_env_vars
+
 # Default token lifetime for Catalyst Center authentication in seconds
 # Catalyst Center tokens are typically valid for 1 hour (3600 seconds) by default
 CATALYST_CENTER_TOKEN_LIFETIME_SECONDS: int = 3600
@@ -250,30 +252,16 @@ else:
             >>> # Use in API requests
             >>> headers = {"X-Auth-Token": auth_data["token"]}
         """
-        url = os.environ.get("CC_URL")
-        username = os.environ.get("CC_USERNAME")
-        password = os.environ.get("CC_PASSWORD")
+        env = require_env_vars("CC_URL", "CC_USERNAME", "CC_PASSWORD")
+        url = env["CC_URL"].rstrip("/")
+        username = env["CC_USERNAME"]
+        password = env["CC_PASSWORD"]
         insecure = os.environ.get("CC_INSECURE", "True").lower() in ("true", "1", "yes")
-
-        if not all([url, username, password]):
-            missing_vars: list[str] = []
-            if not url:
-                missing_vars.append("CC_URL")
-            if not username:
-                missing_vars.append("CC_USERNAME")
-            if not password:
-                missing_vars.append("CC_PASSWORD")
-            raise ValueError(
-                f"Missing required environment variables: {', '.join(missing_vars)}"
-            )
-
-        # Normalize URL by removing trailing slash
-        url = url.rstrip("/")  # type: ignore[union-attr]
         verify_ssl = not insecure  # CC_INSECURE=True means verify=False
 
         def auth_wrapper() -> tuple[dict[str, Any], int]:
             """Wrapper for authentication that captures closure variables."""
-            return cls._authenticate(url, username, password, verify_ssl)  # type: ignore[arg-type]
+            return cls._authenticate(url, username, password, verify_ssl)
 
         # AuthCache.get_or_create returns dict[str, Any], but mypy can't verify this
         # because nac_test lacks py.typed marker.

--- a/src/nac_test_pyats_common/catc/auth.py
+++ b/src/nac_test_pyats_common/catc/auth.py
@@ -64,7 +64,7 @@ class CatalystCenterAuth:
     - Modern Catalyst Center 2.x: /api/system/v1/auth/token endpoint
     - Legacy DNA Center 1.x/2.x: /dna/system/api/v1/auth/token endpoint
 
-    The class mirrors VManageAuth pattern for consistency across NAC adapters.
+    The class mirrors SDWANManagerAuth pattern for consistency across NAC adapters.
 
     Example:
         >>> # Get authentication data for Catalyst Center API calls

--- a/src/nac_test_pyats_common/common/env.py
+++ b/src/nac_test_pyats_common/common/env.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2025 Daniel Schmidt
+
+"""Environment variable helpers shared across auth modules."""
+
+import os
+
+
+def require_env_vars(*var_names: str) -> dict[str, str]:
+    """Read environment variables and raise if any are missing or empty.
+
+    Args:
+        *var_names: Names of the required environment variables.
+
+    Returns:
+        A dictionary mapping each variable name to its non-empty string value.
+
+    Raises:
+        ValueError: If one or more variables are unset or empty, listing all
+            missing names.
+    """
+    values = {name: os.environ.get(name) for name in var_names}
+    missing = [name for name, val in values.items() if not val]
+    if missing:
+        raise ValueError(
+            f"Missing required environment variables: {', '.join(missing)}"
+        )
+    return values  # type: ignore[return-value]

--- a/src/nac_test_pyats_common/sdwan/__init__.py
+++ b/src/nac_test_pyats_common/sdwan/__init__.py
@@ -8,8 +8,8 @@ resolver implementations for use with the nac-test framework. It includes suppor
 for both SDWAN Manager API testing and SSH-based device-to-device (D2D) testing.
 
 Classes:
-    SDWANManagerAuth: SDWAN Manager authentication with JSESSIONID and XSRF token
-        management.
+    SDWANManagerAuth: SDWAN Manager authentication with session auth (JSESSIONID +
+        XSRF token) and API token auth (JWT Bearer + CSRF, 20.18+).
     SDWANManagerTestBase: Base class for SDWAN Manager API tests with tracking.
     SDWANTestBase: Base class for SD-WAN SSH/D2D tests with device inventory.
     SDWANDeviceResolver: Resolves device information from the SD-WAN data model.

--- a/src/nac_test_pyats_common/sdwan/api_test_base.py
+++ b/src/nac_test_pyats_common/sdwan/api_test_base.py
@@ -110,18 +110,16 @@ class SDWANManagerTestBase(NACTestBase):  # type: ignore[misc]
         Configured with response tracking.
 
         Creates an HTTP client specifically configured for SDWAN Manager API
-        communication with session headers, base URL, and automatic response
+        communication with appropriate auth headers, base URL, and automatic response
         tracking for HTML report generation. The client is wrapped to capture all
         API interactions for detailed test reporting.
 
-        The client includes:
-        - JSESSIONID cookie in all requests (via Cookie header)
-        - X-XSRF-TOKEN header when available (19.2+)
-        - Content-Type: application/json header
-        - Automatic API call tracking for reporting
+        Supports two authentication modes (determined by auth_data["auth_method"]):
+        - **token**: Uses Authorization: Bearer header (SD-WAN Manager 20.18+)
+        - **session**: Uses JSESSIONID cookie + optional X-XSRF-TOKEN header
 
         Returns:
-            httpx.AsyncClient: Configured client with SDWAN Manager session data,
+            httpx.AsyncClient: Configured client with SDWAN Manager auth headers,
                 base URL, and wrapped for automatic API call tracking. The client
                 has SSL verification disabled for lab environment compatibility.
 
@@ -130,15 +128,18 @@ class SDWANManagerTestBase(NACTestBase):  # type: ignore[misc]
             with self-signed certificates. For production environments, consider
             enabling SSL verification with proper certificate management.
         """
-        # Build headers with Cookie header (following APIC pattern for consistency)
-        headers = {
-            "Cookie": f"JSESSIONID={self.auth_data['jsessionid']}",
-            "Content-Type": "application/json",
-        }
+        headers: dict[str, str] = {"Content-Type": "application/json"}
 
-        # Add XSRF token if available (19.2+ requires this for CSRF protection)
-        if self.auth_data.get("xsrf_token"):
-            headers["X-XSRF-TOKEN"] = self.auth_data["xsrf_token"]
+        auth_method = self.auth_data.get("auth_method", "session")
+
+        if auth_method == "token":
+            # Bearer token auth (SD-WAN Manager 20.18+)
+            headers["Authorization"] = f"Bearer {self.auth_data['api_token']}"
+        else:
+            # Session-based auth (JSESSIONID + optional XSRF token)
+            headers["Cookie"] = f"JSESSIONID={self.auth_data['jsessionid']}"
+            if self.auth_data.get("xsrf_token"):
+                headers["X-XSRF-TOKEN"] = self.auth_data["xsrf_token"]
 
         # Get base client from pool with SSL verification disabled for lab compatibility
         base_client = self.pool.get_client(

--- a/src/nac_test_pyats_common/sdwan/api_test_base.py
+++ b/src/nac_test_pyats_common/sdwan/api_test_base.py
@@ -110,18 +110,16 @@ class SDWANManagerTestBase(NACTestBase):  # type: ignore[misc]
         Configured with response tracking.
 
         Creates an HTTP client specifically configured for SDWAN Manager API
-        communication with session headers, base URL, and automatic response
-        tracking for HTML report generation. The client is wrapped to capture all
-        API interactions for detailed test reporting.
+        communication with appropriate authentication headers, base URL, and
+        automatic response tracking for HTML report generation. The client is
+        wrapped to capture all API interactions for detailed test reporting.
 
-        The client includes:
-        - JSESSIONID cookie in all requests (via Cookie header)
-        - X-XSRF-TOKEN header when available (19.2+)
-        - Content-Type: application/json header
-        - Automatic API call tracking for reporting
+        The client supports two authentication modes based on auth_data['auth_type']:
+        - 'session': JSESSIONID cookie + optional X-XSRF-TOKEN (pre-20.18)
+        - 'token': Bearer Authorization + X-XSRF-TOKEN from JWT CSRF (20.18+)
 
         Returns:
-            httpx.AsyncClient: Configured client with SDWAN Manager session data,
+            httpx.AsyncClient: Configured client with SDWAN Manager auth data,
                 base URL, and wrapped for automatic API call tracking. The client
                 has SSL verification disabled for lab environment compatibility.
 
@@ -130,15 +128,25 @@ class SDWANManagerTestBase(NACTestBase):  # type: ignore[misc]
             with self-signed certificates. For production environments, consider
             enabling SSL verification with proper certificate management.
         """
-        # Build headers with Cookie header (following APIC pattern for consistency)
-        headers = {
-            "Cookie": f"JSESSIONID={self.auth_data['jsessionid']}",
-            "Content-Type": "application/json",
-        }
+        auth_type = self.auth_data.get("auth_type", "session")
 
-        # Add XSRF token if available (19.2+ requires this for CSRF protection)
-        if self.auth_data.get("xsrf_token"):
-            headers["X-XSRF-TOKEN"] = self.auth_data["xsrf_token"]
+        if auth_type == "token":
+            # API token auth (20.18+): Bearer + X-XSRF-TOKEN from JWT CSRF
+            headers = {
+                "Authorization": f"Bearer {self.auth_data['api_token']}",
+                "X-XSRF-TOKEN": self.auth_data["csrf_token"],
+                "Content-Type": "application/json",
+                "accept": "application/json",
+            }
+        else:
+            # Session auth: Cookie + optional X-XSRF-TOKEN
+            headers = {
+                "Cookie": f"JSESSIONID={self.auth_data['jsessionid']}",
+                "Content-Type": "application/json",
+            }
+            # Add XSRF token if available (19.2+ requires this for CSRF protection)
+            if self.auth_data.get("xsrf_token"):
+                headers["X-XSRF-TOKEN"] = self.auth_data["xsrf_token"]
 
         # Get base client from pool with SSL verification disabled for lab compatibility
         base_client = self.pool.get_client(

--- a/src/nac_test_pyats_common/sdwan/api_test_base.py
+++ b/src/nac_test_pyats_common/sdwan/api_test_base.py
@@ -136,11 +136,13 @@ class SDWANManagerTestBase(NACTestBase):  # type: ignore[misc]
             # Bearer token auth (SD-WAN Manager 20.18+)
             headers["Authorization"] = f"Bearer {self.auth_data['api_token']}"
             headers["X-XSRF-TOKEN"] = self.auth_data["csrf_token"]
-        else:
+        elif auth_method == "session":
             # Session-based auth (JSESSIONID + optional XSRF token)
             headers["Cookie"] = f"JSESSIONID={self.auth_data['jsessionid']}"
             if self.auth_data.get("xsrf_token"):
                 headers["X-XSRF-TOKEN"] = self.auth_data["xsrf_token"]
+        else:
+            raise ValueError(f"Unsupported auth_method: {auth_method!r}")
 
         # Get base client from pool with SSL verification disabled for lab compatibility
         base_client = self.pool.get_client(

--- a/src/nac_test_pyats_common/sdwan/api_test_base.py
+++ b/src/nac_test_pyats_common/sdwan/api_test_base.py
@@ -115,7 +115,7 @@ class SDWANManagerTestBase(NACTestBase):  # type: ignore[misc]
         wrapped to capture all API interactions for detailed test reporting.
 
         The client supports two authentication modes based on auth_data['auth_type']:
-        - 'session': JSESSIONID cookie + optional X-XSRF-TOKEN (pre-20.18)
+        - 'session': JSESSIONID cookie + optional X-XSRF-TOKEN (19.2+)
         - 'token': Bearer Authorization + X-XSRF-TOKEN from JWT CSRF (20.18+)
 
         Returns:

--- a/src/nac_test_pyats_common/sdwan/api_test_base.py
+++ b/src/nac_test_pyats_common/sdwan/api_test_base.py
@@ -29,28 +29,31 @@ class SDWANManagerTestBase(NACTestBase):  # type: ignore[misc]
     """Base class for SDWAN Manager API tests with enhanced reporting.
 
     This class extends the generic NACTestBase to provide SDWAN Manager-specific
-    functionality including session management (JSESSIONID and optional XSRF token),
-    API call tracking for HTML reports, and wrapped HTTP client for automatic
-    response capture. It serves as the foundation for all SD-WAN controller-specific
+    functionality including authentication (token or session-based), API call
+    tracking for HTML reports, and wrapped HTTP client for automatic response
+    capture. It serves as the foundation for all SD-WAN controller-specific
     API test classes.
 
     The class follows the same pattern as APICTestBase for consistency across
-    NAC architecture adapters. Token refresh is handled automatically by the
-    AuthCache TTL mechanism.
+    NAC architecture adapters.
+
+    Two authentication modes are supported (determined by SDWANManagerAuth):
+    - **Token auth** (20.18+): Bearer Authorization + X-XSRF-TOKEN from JWT.
+    - **Session auth** (all versions): JSESSIONID cookie + optional X-XSRF-TOKEN.
+      Session refresh is handled automatically by the AuthCache TTL mechanism.
 
     Attributes:
-        auth_data (dict): SDWAN Manager authentication data containing jsessionid and
-            optional xsrf_token obtained during setup.
+        auth_data (dict): SDWAN Manager authentication data from get_auth().
+            Contains auth_method plus mode-specific keys (api_token/csrf_token
+            for token auth, jsessionid/xsrf_token for session auth).
         client (httpx.AsyncClient | None): Wrapped async HTTP client configured for
-            SDWAN Manager. Initialized to None, set during setup().
+            SDWAN Manager. Initialized to None, set during run_async_verification_test().
         controller_url (str): Base URL of the SDWAN Manager (inherited).
-        username (str): SDWAN Manager username for authentication (inherited).
-        password (str): SDWAN Manager password for authentication (inherited).
 
     Methods:
-        setup(): Initialize SDWAN Manager authentication and client.
+        setup(): Initialize SDWAN Manager authentication.
         get_sdwan_manager_client(): Create and configure an SDWAN Manager-specific
-            HTTP client.
+            HTTP client with the appropriate auth headers.
         run_async_verification_test(): Execute async verification tests with PyATS.
 
     Example:

--- a/src/nac_test_pyats_common/sdwan/api_test_base.py
+++ b/src/nac_test_pyats_common/sdwan/api_test_base.py
@@ -135,6 +135,7 @@ class SDWANManagerTestBase(NACTestBase):  # type: ignore[misc]
         if auth_method == "token":
             # Bearer token auth (SD-WAN Manager 20.18+)
             headers["Authorization"] = f"Bearer {self.auth_data['api_token']}"
+            headers["X-XSRF-TOKEN"] = self.auth_data["csrf_token"]
         else:
             # Session-based auth (JSESSIONID + optional XSRF token)
             headers["Cookie"] = f"JSESSIONID={self.auth_data['jsessionid']}"

--- a/src/nac_test_pyats_common/sdwan/auth.py
+++ b/src/nac_test_pyats_common/sdwan/auth.py
@@ -391,14 +391,20 @@ class SDWANManagerAuth:
             # Add padding for base64 decoding
             payload_b64 += "=" * (-len(payload_b64) % 4)
             payload = json.loads(base64.urlsafe_b64decode(payload_b64))
-        except Exception as e:
+        except (json.JSONDecodeError, UnicodeDecodeError, ValueError) as e:
             raise ValueError(
                 "Failed to decode SDWAN_API_TOKEN: not a valid JWT. "
                 "Verify the token format (header.payload.signature)."
             ) from e
 
+        if not isinstance(payload, dict):
+            raise ValueError(
+                "SDWAN_API_TOKEN JWT payload is not a JSON object. "
+                "Verify the token was generated correctly."
+            )
+
         csrf_token = payload.get("csrf", "")
-        if not csrf_token:
+        if not isinstance(csrf_token, str) or not csrf_token:
             raise ValueError(
                 "SDWAN_API_TOKEN is missing 'csrf' field in JWT payload. "
                 "Verify the token was generated correctly."

--- a/src/nac_test_pyats_common/sdwan/auth.py
+++ b/src/nac_test_pyats_common/sdwan/auth.py
@@ -44,6 +44,8 @@ from nac_test.pyats_core.common.subprocess_auth import (
     execute_auth_subprocess,
 )
 
+from nac_test_pyats_common.common.env import require_env_vars
+
 try:
     from nac_test.utils.controller import get_matched_credential_set
 except ImportError:
@@ -373,21 +375,11 @@ class SDWANManagerAuth:
             ValueError: If SDWAN_URL or SDWAN_API_TOKEN is not set, or if the
                 token is not a valid JWT or is missing the 'csrf' field.
         """
-        url = os.environ.get("SDWAN_URL")
-        api_token = os.environ.get("SDWAN_API_TOKEN")
-
-        if not all([url, api_token]):
-            missing_vars: list[str] = []
-            if not url:
-                missing_vars.append("SDWAN_URL")
-            if not api_token:
-                missing_vars.append("SDWAN_API_TOKEN")
-            raise ValueError(
-                f"Missing required environment variables: {', '.join(missing_vars)}"
-            )
+        env = require_env_vars("SDWAN_URL", "SDWAN_API_TOKEN")
+        api_token = env["SDWAN_API_TOKEN"]
 
         # Decode JWT payload to extract CSRF token
-        parts = api_token.split(".")  # type: ignore[union-attr]
+        parts = api_token.split(".")
         if len(parts) != 3:  # noqa: PLR2004
             raise ValueError(
                 "SDWAN_API_TOKEN is not a valid JWT: expected 3 dot-separated "
@@ -432,36 +424,22 @@ class SDWANManagerAuth:
             ValueError: If SDWAN_URL, SDWAN_USERNAME, or SDWAN_PASSWORD is not set.
             SubprocessAuthError: If authentication fails.
         """
-        url = os.environ.get("SDWAN_URL")
-        username = os.environ.get("SDWAN_USERNAME")
-        password = os.environ.get("SDWAN_PASSWORD")
+        env = require_env_vars("SDWAN_URL", "SDWAN_USERNAME", "SDWAN_PASSWORD")
+        url = env["SDWAN_URL"].rstrip("/")
+        username = env["SDWAN_USERNAME"]
+        password = env["SDWAN_PASSWORD"]
         insecure = os.environ.get("SDWAN_INSECURE", "True").lower() in (
             "true",
             "1",
             "yes",
         )
 
-        if not all([url, username, password]):
-            missing_vars: list[str] = []
-            if not url:
-                missing_vars.append("SDWAN_URL")
-            if not username:
-                missing_vars.append("SDWAN_USERNAME")
-            if not password:
-                missing_vars.append("SDWAN_PASSWORD")
-            raise ValueError(
-                f"Missing required environment variables: {', '.join(missing_vars)}"
-            )
-
-        # Normalize URL by removing trailing slash
-        url = url.rstrip("/")  # type: ignore[union-attr]
-
         # SDWAN_INSECURE=True means verify_ssl=False
         verify_ssl = not insecure
 
         def auth_wrapper() -> tuple[dict[str, Any], int]:
             """Wrapper for authentication that captures closure variables."""
-            return cls._authenticate(url, username, password, verify_ssl)  # type: ignore[arg-type]
+            return cls._authenticate(url, username, password, verify_ssl)
 
         # AuthCache.get_or_create returns dict[str, Any], but mypy can't verify this
         # because nac_test lacks py.typed marker.

--- a/src/nac_test_pyats_common/sdwan/auth.py
+++ b/src/nac_test_pyats_common/sdwan/auth.py
@@ -194,29 +194,34 @@ if auth_body is not None:
 
 
 class SDWANManagerAuth:
-    """SDWAN Manager authentication implementation with session caching.
+    """SDWAN Manager authentication implementation.
 
-    This class provides a two-tier API for SDWAN Manager authentication:
+    This class provides a multi-tier API for SDWAN Manager authentication:
 
-    1. Low-level _authenticate() method: Directly authenticates with SDWAN Manager using
-       form-based login and returns session data along with expiration time. This is
-       typically used by the caching layer and not called directly by consumers.
+    1. High-level get_auth() method: Routes to the appropriate auth method based
+       on the credential set matched by nac-test's controller detection. This is
+       the primary method that consumers should use.
+    2. _get_token_auth(): JWT-based Bearer authentication (SD-WAN Manager 20.18+).
+       Extracts the CSRF token from the JWT payload. No network call required.
+    3. _get_session_auth(): Form-based login with cached session management via
+       AuthCache. Automatically handles session renewal when expired.
+    4. _authenticate(): Low-level subprocess-based session auth. Used internally
+       by _get_session_auth() via AuthCache.
 
-    2. High-level get_auth() method: Provides cached session management, automatically
-       handling session renewal when expired. This is the primary method that consumers
-       should use for obtaining SDWAN Manager authentication data.
-
-    The authentication flow supports both:
+    The authentication flow supports:
+    - 20.18+ versions: Bearer token auth with CSRF from JWT payload
+    - 19.2+ versions: JSESSIONID cookie plus X-XSRF-TOKEN header
     - Pre-19.2 versions: JSESSIONID cookie only
-    - 19.2+ versions: JSESSIONID cookie plus X-XSRF-TOKEN header for CSRF protection
 
     Example:
-        >>> # Get authentication data for SDWAN Manager API calls
         >>> auth_data = SDWANManagerAuth.get_auth()
-        >>> # Use in requests
-        >>> headers = {"Cookie": f"JSESSIONID={auth_data['jsessionid']}"}
-        >>> if auth_data.get("xsrf_token"):
-        ...     headers["X-XSRF-TOKEN"] = auth_data["xsrf_token"]
+        >>> if auth_data["auth_method"] == "token":
+        ...     headers = {"Authorization": f"Bearer {auth_data['api_token']}"}
+        ...     headers["X-XSRF-TOKEN"] = auth_data["csrf_token"]
+        >>> else:
+        ...     headers = {"Cookie": f"JSESSIONID={auth_data['jsessionid']}"}
+        ...     if auth_data.get("xsrf_token"):
+        ...         headers["X-XSRF-TOKEN"] = auth_data["xsrf_token"]
     """
 
     @staticmethod

--- a/src/nac_test_pyats_common/sdwan/auth.py
+++ b/src/nac_test_pyats_common/sdwan/auth.py
@@ -64,7 +64,8 @@ AUTH_REQUEST_TIMEOUT_SECONDS: float = 30.0
 #   Input:  `params` dict with keys: url, username, password, timeout,
 #           xsrf_timeout, verify_ssl
 #   Output: `result` dict with either:
-#           - {"jsessionid": str, "xsrf_token": str | None}  (success)
+#           - {"jsessionid": str, "xsrf_token": str | None,
+#              "auth_type": "session"}                         (success)
 #           - {"error": str}                                   (failure)
 _AUTH_SCRIPT_BODY: str = """
 import http.cookiejar

--- a/src/nac_test_pyats_common/sdwan/auth.py
+++ b/src/nac_test_pyats_common/sdwan/auth.py
@@ -4,13 +4,23 @@
 """SDWAN Manager authentication implementation for Cisco SD-WAN.
 
 This module provides authentication functionality for Cisco SDWAN Manager (formerly
-vManage), which manages the software-defined WAN fabric. The authentication mechanism
-uses form-based login with JSESSIONID cookie and optional XSRF token for CSRF
-protection.
+vManage), which manages the software-defined WAN fabric. Two authentication
+methods are supported:
 
-The module implements a two-tier API design:
-1. _authenticate() - Low-level method that performs direct SDWAN Manager authentication
-2. get_auth() - High-level method that leverages caching for efficient token reuse
+1. **Token auth** (20.18+): JWT-based Bearer authentication using a pre-generated
+   API token. The CSRF token is extracted from the JWT payload and must be sent
+   as the X-XSRF-TOKEN header alongside the Bearer Authorization header.
+2. **Session auth** (all versions): Form-based login with JSESSIONID cookie and
+   optional XSRF token for CSRF protection.
+
+The auth method is determined by `get_matched_credential_set()` from nac-test's
+controller detection module.
+
+The module implements a multi-tier API design:
+1. _authenticate() - Low-level method that performs direct SDWAN Manager session authentication
+2. _get_token_auth() - Low-level method for JWT-based token authentication
+3. _get_session_auth() - Low-level method for session-based authentication
+4. get_auth() - High-level method that routes to the appropriate auth method
 
 This design ensures efficient session management by reusing valid sessions and only
 re-authenticating when necessary, reducing unnecessary API calls to the SDWAN Manager.
@@ -22,6 +32,8 @@ Note on Fork Safety:
     that work correctly after fork().
 """
 
+import base64
+import json
 import os
 from typing import Any
 
@@ -333,14 +345,19 @@ class SDWANManagerAuth:
     def _get_token_auth(cls) -> dict[str, Any]:
         """Get token-based authentication data (SD-WAN Manager 20.18+).
 
-        Reads SDWAN_API_TOKEN from the environment and returns it for use
-        as a Bearer token. No network call or caching required.
+        Reads SDWAN_API_TOKEN from the environment and decodes the JWT payload
+        to extract the CSRF token. No network call or caching required.
+
+        The JWT payload is expected to contain a 'csrf' field which must be
+        sent as the X-XSRF-TOKEN header alongside the Bearer Authorization
+        header on API requests.
 
         Returns:
-            Dictionary with auth_method="token" and the api_token value.
+            Dictionary with auth_method="token", api_token, and csrf_token.
 
         Raises:
-            ValueError: If SDWAN_URL or SDWAN_API_TOKEN is not set.
+            ValueError: If SDWAN_URL or SDWAN_API_TOKEN is not set, or if the
+                token is not a valid JWT or is missing the 'csrf' field.
         """
         url = os.environ.get("SDWAN_URL")
         api_token = os.environ.get("SDWAN_API_TOKEN")
@@ -355,7 +372,37 @@ class SDWANManagerAuth:
                 f"Missing required environment variables: {', '.join(missing_vars)}"
             )
 
-        return {"auth_method": "token", "api_token": api_token}
+        # Decode JWT payload to extract CSRF token
+        parts = api_token.split(".")  # type: ignore[union-attr]
+        if len(parts) != 3:  # noqa: PLR2004
+            raise ValueError(
+                "SDWAN_API_TOKEN is not a valid JWT: expected 3 dot-separated "
+                "parts (header.payload.signature), "
+                f"got {len(parts)}."
+            )
+        try:
+            payload_b64 = parts[1]
+            # Add padding for base64 decoding
+            payload_b64 += "=" * (-len(payload_b64) % 4)
+            payload = json.loads(base64.urlsafe_b64decode(payload_b64))
+        except Exception as e:
+            raise ValueError(
+                "Failed to decode SDWAN_API_TOKEN: not a valid JWT. "
+                "Verify the token format (header.payload.signature)."
+            ) from e
+
+        csrf_token = payload.get("csrf", "")
+        if not csrf_token:
+            raise ValueError(
+                "SDWAN_API_TOKEN is missing 'csrf' field in JWT payload. "
+                "Verify the token was generated correctly."
+            )
+
+        return {
+            "auth_method": "token",
+            "api_token": api_token,
+            "csrf_token": csrf_token,
+        }
 
     @classmethod
     def _get_session_auth(cls) -> dict[str, Any]:

--- a/src/nac_test_pyats_common/sdwan/auth.py
+++ b/src/nac_test_pyats_common/sdwan/auth.py
@@ -304,21 +304,19 @@ class SDWANManagerAuth:
             ValueError: If the token is not a valid JWT or is missing the
                 'csrf' field in its payload.
         """
+        parts = api_token.split(".")
+        if len(parts) != 3:  # noqa: PLR2004
+            raise ValueError(
+                "SDWAN_API_TOKEN is not a valid JWT: expected 3 dot-separated "
+                "parts (header.payload.signature), "
+                f"got {len(parts)}."
+            )
         try:
-            parts = api_token.split(".")
-            if len(parts) != 3:  # noqa: PLR2004
-                raise ValueError(
-                    "SDWAN_API_TOKEN is not a valid JWT: expected 3 dot-separated "
-                    "parts (header.payload.signature), "
-                    f"got {len(parts)}."
-                )
             payload_b64 = parts[1]
             # Add padding for base64 decoding
             payload_b64 += "=" * (-len(payload_b64) % 4)
             payload = json.loads(base64.urlsafe_b64decode(payload_b64))
-        except (json.JSONDecodeError, UnicodeDecodeError, Exception) as e:
-            if isinstance(e, ValueError):
-                raise
+        except Exception as e:
             raise ValueError(
                 "Failed to decode SDWAN_API_TOKEN: not a valid JWT. "
                 "Verify the token format (header.payload.signature)."

--- a/src/nac_test_pyats_common/sdwan/auth.py
+++ b/src/nac_test_pyats_common/sdwan/auth.py
@@ -260,48 +260,116 @@ class SDWANManagerAuth:
         """Get SDWAN Manager authentication data with automatic caching and renewal.
 
         This is the primary method that consumers should use to obtain SDWAN Manager
-        authentication data. It leverages the AuthCache to efficiently manage
-        session lifecycle, reusing valid sessions and automatically renewing
-        expired ones. This significantly reduces the number of authentication
-        requests to the SDWAN Manager.
+        authentication data. It consults the credential set matched by nac-test's
+        detect_controller_type() to determine the authentication mechanism:
+
+        - **Token auth** (auth_method="token"): Uses SDWAN_API_TOKEN directly.
+          No session login required. Returns immediately with the bearer token.
+          Available on SD-WAN Manager 20.18+.
+
+        - **Session auth** (auth_method="session"): Uses SDWAN_USERNAME/SDWAN_PASSWORD
+          to perform form-based login, obtaining a JSESSIONID cookie and optional
+          XSRF token. Leverages AuthCache for efficient session reuse.
 
         The method uses a cache key based on the controller type ("SDWAN_MANAGER")
         and URL to ensure proper session isolation between different SDWAN Manager
         instances.
 
-        Environment Variables Required:
+        Environment Variables Required (session auth):
             SDWAN_URL: Base URL of the SDWAN Manager
             SDWAN_USERNAME: SDWAN Manager username for authentication
             SDWAN_PASSWORD: SDWAN Manager password for authentication
             SDWAN_INSECURE: If "True", "1", or "yes" (default: "True"), SSL certificate
                 verification is disabled. Set to "False" to enable SSL verification.
 
+        Environment Variables Required (token auth):
+            SDWAN_URL: Base URL of the SDWAN Manager
+            SDWAN_API_TOKEN: API token for bearer authentication (20.18+)
+
         Returns:
             A dictionary containing:
-                - jsessionid (str): The session cookie value for API requests
-                - xsrf_token (str | None): The XSRF token for CSRF protection
-                  (None for pre-19.2 versions)
+                - auth_method (str): "token" or "session"
+                - api_token (str): Bearer token (only when auth_method="token")
+                - jsessionid (str): Session cookie (only when auth_method="session")
+                - xsrf_token (str | None): XSRF token (only when auth_method="session")
 
         Raises:
-            ValueError: If any required environment variables (SDWAN_URL,
-                SDWAN_USERNAME, SDWAN_PASSWORD) are not set.
-            SubprocessAuthError: If authentication fails due to invalid credentials,
-                network issues, connection timeouts, or SDWAN Manager server errors.
-                The error message will contain details from the authentication
-                subprocess.
+            ValueError: If required environment variables are not set for the
+                determined auth method.
+            SubprocessAuthError: If session authentication fails due to invalid
+                credentials, network issues, connection timeouts, or SDWAN Manager
+                server errors.
 
         Example:
-            >>> # Set environment variables first
-            >>> import os
+            >>> # Token auth (20.18+)
+            >>> os.environ["SDWAN_URL"] = "https://sdwan-manager.example.com"
+            >>> os.environ["SDWAN_API_TOKEN"] = "my-api-token"
+            >>> auth_data = SDWANManagerAuth.get_auth()
+            >>> auth_data["auth_method"]
+            'token'
+            >>> headers = {"Authorization": f"Bearer {auth_data['api_token']}"}
+
+            >>> # Session auth (legacy)
             >>> os.environ["SDWAN_URL"] = "https://sdwan-manager.example.com"
             >>> os.environ["SDWAN_USERNAME"] = "admin"
             >>> os.environ["SDWAN_PASSWORD"] = "password123"
-            >>> # Get authentication data
             >>> auth_data = SDWANManagerAuth.get_auth()
-            >>> # Use in API requests
+            >>> auth_data["auth_method"]
+            'session'
             >>> headers = {"Cookie": f"JSESSIONID={auth_data['jsessionid']}"}
-            >>> if auth_data.get("xsrf_token"):
-            ...     headers["X-XSRF-TOKEN"] = auth_data["xsrf_token"]
+        """
+        from nac_test.utils.controller import get_matched_credential_set
+
+        # Determine auth method from the credential set matched during detection
+        matched = get_matched_credential_set("SDWAN")
+        auth_method = matched.auth_method if matched else "session"
+
+        if auth_method == "token":
+            return cls._get_token_auth()
+
+        return cls._get_session_auth()
+
+    @classmethod
+    def _get_token_auth(cls) -> dict[str, Any]:
+        """Get token-based authentication data (SD-WAN Manager 20.18+).
+
+        Reads SDWAN_API_TOKEN from the environment and returns it for use
+        as a Bearer token. No network call or caching required.
+
+        Returns:
+            Dictionary with auth_method="token" and the api_token value.
+
+        Raises:
+            ValueError: If SDWAN_URL or SDWAN_API_TOKEN is not set.
+        """
+        url = os.environ.get("SDWAN_URL")
+        api_token = os.environ.get("SDWAN_API_TOKEN")
+
+        if not all([url, api_token]):
+            missing_vars: list[str] = []
+            if not url:
+                missing_vars.append("SDWAN_URL")
+            if not api_token:
+                missing_vars.append("SDWAN_API_TOKEN")
+            raise ValueError(
+                f"Missing required environment variables: {', '.join(missing_vars)}"
+            )
+
+        return {"auth_method": "token", "api_token": api_token}
+
+    @classmethod
+    def _get_session_auth(cls) -> dict[str, Any]:
+        """Get session-based authentication data (username/password login).
+
+        Performs form-based login to obtain JSESSIONID and optional XSRF token,
+        with caching via AuthCache for session reuse.
+
+        Returns:
+            Dictionary with auth_method="session", jsessionid, and xsrf_token.
+
+        Raises:
+            ValueError: If SDWAN_URL, SDWAN_USERNAME, or SDWAN_PASSWORD is not set.
+            SubprocessAuthError: If authentication fails.
         """
         url = os.environ.get("SDWAN_URL")
         username = os.environ.get("SDWAN_USERNAME")
@@ -336,8 +404,10 @@ class SDWANManagerAuth:
 
         # AuthCache.get_or_create returns dict[str, Any], but mypy can't verify this
         # because nac_test lacks py.typed marker.
-        return AuthCache.get_or_create(  # type: ignore[no-any-return]
+        session_data: dict[str, Any] = AuthCache.get_or_create(  # type: ignore[no-any-return]
             controller_type="SDWAN_MANAGER",
             url=url,
             auth_func=auth_wrapper,
         )
+
+        return {"auth_method": "session", **session_data}

--- a/src/nac_test_pyats_common/sdwan/auth.py
+++ b/src/nac_test_pyats_common/sdwan/auth.py
@@ -17,7 +17,7 @@ The auth method is determined by `get_matched_credential_set()` from nac-test's
 controller detection module.
 
 The module implements a multi-tier API design:
-1. _authenticate() - Low-level method that performs direct SDWAN Manager session authentication
+1. _authenticate() - Low-level: direct SDWAN Manager session auth
 2. _get_token_auth() - Low-level method for JWT-based token authentication
 3. _get_session_auth() - Low-level method for session-based authentication
 4. get_auth() - High-level method that routes to the appropriate auth method

--- a/src/nac_test_pyats_common/sdwan/auth.py
+++ b/src/nac_test_pyats_common/sdwan/auth.py
@@ -50,12 +50,6 @@ logger = logging.getLogger(__name__)
 # SDWAN Manager sessions are typically valid for 30 minutes (1800 seconds) by default
 SDWAN_MANAGER_SESSION_LIFETIME_SECONDS: int = 1800
 
-# Default cache lifetime for API token authentication in seconds
-# API tokens have their own expiration (set by admin), but we cache the decoded
-# result for 1 hour to avoid re-decoding on every test. The JWT itself is validated
-# server-side on each request, so an expired token will fail at request time.
-SDWAN_API_TOKEN_CACHE_LIFETIME_SECONDS: int = 3600
-
 # HTTP timeout for XSRF token fetch (shorter than auth timeout since it's optional)
 XSRF_TOKEN_FETCH_TIMEOUT_SECONDS: float = 10.0
 
@@ -288,7 +282,7 @@ class SDWANManagerAuth:
     @staticmethod
     def _authenticate_with_api_token(
         api_token: str,
-    ) -> tuple[dict[str, Any], int]:
+    ) -> dict[str, Any]:
         """Authenticate using a pre-generated API token (JWT) for SD-WAN 20.18+.
 
         This method decodes the JWT payload to extract the CSRF token without
@@ -303,10 +297,8 @@ class SDWANManagerAuth:
                 environment variable).
 
         Returns:
-            A tuple containing:
-                - auth_dict (dict): Dictionary with 'api_token' (str),
-                  'csrf_token' (str), and 'auth_type' set to 'token'.
-                - expires_in (int): Cache lifetime in seconds.
+            Dictionary with 'api_token' (str), 'csrf_token' (str), and
+            'auth_type' set to 'token'.
 
         Raises:
             ValueError: If the token is not a valid JWT or is missing the
@@ -345,7 +337,7 @@ class SDWANManagerAuth:
             "api_token": api_token,
             "csrf_token": csrf_token,
             "auth_type": "token",
-        }, SDWAN_API_TOKEN_CACHE_LIFETIME_SECONDS
+        }
 
     @classmethod
     def get_auth(cls) -> dict[str, Any]:
@@ -407,8 +399,7 @@ class SDWANManagerAuth:
         # No caching for API token auth — JWT decoding is cheap (no network call)
         # and caching causes stale-token issues when the env var is updated.
         if api_token:
-            auth_data, _ = cls._authenticate_with_api_token(api_token)
-            return auth_data
+            return cls._authenticate_with_api_token(api_token)
 
         # Fall back to session-based authentication
         username = os.environ.get("SDWAN_USERNAME")
@@ -427,8 +418,8 @@ class SDWANManagerAuth:
                 missing_vars.append("SDWAN_PASSWORD")
             raise ValueError(
                 f"Missing required environment variables: {', '.join(missing_vars)}. "
-                "Provide SDWAN_API_TOKEN for token auth, or SDWAN_USERNAME and "
-                "SDWAN_PASSWORD for session auth."
+                "Provide SDWAN_API_TOKEN for token auth (SD-WAN 20.18+), or "
+                "SDWAN_USERNAME and SDWAN_PASSWORD for session auth."
             )
 
         # SDWAN_INSECURE=True means verify_ssl=False

--- a/src/nac_test_pyats_common/sdwan/auth.py
+++ b/src/nac_test_pyats_common/sdwan/auth.py
@@ -4,24 +4,37 @@
 """SDWAN Manager authentication implementation for Cisco SD-WAN.
 
 This module provides authentication functionality for Cisco SDWAN Manager (formerly
-vManage), which manages the software-defined WAN fabric. The authentication mechanism
-uses form-based login with JSESSIONID cookie and optional XSRF token for CSRF
-protection.
+vManage), which manages the software-defined WAN fabric. Two authentication methods
+are supported:
+
+1. **Session auth** (all versions): Form-based login with JSESSIONID cookie and
+   optional XSRF token for CSRF protection.
+2. **API token auth** (20.18+): Bearer token authentication using a pre-generated
+   JWT. The CSRF token is extracted from the JWT payload. No network call is needed
+   for authentication — the token is provided via the SDWAN_API_TOKEN environment
+   variable.
+
+When SDWAN_API_TOKEN is set, it takes priority over username/password credentials.
 
 The module implements a two-tier API design:
 1. _authenticate() - Low-level method that performs direct SDWAN Manager authentication
-2. get_auth() - High-level method that leverages caching for efficient token reuse
+2. _authenticate_with_api_token() - Low-level method for JWT-based authentication
+3. get_auth() - High-level method that leverages caching for efficient token reuse
 
 This design ensures efficient session management by reusing valid sessions and only
 re-authenticating when necessary, reducing unnecessary API calls to the SDWAN Manager.
 
 Note on Fork Safety:
-    This module uses urllib instead of httpx for synchronous authentication requests.
-    httpx is NOT fork-safe on macOS - creating httpx.Client after fork() causes
-    silent crashes due to OpenSSL threading issues. urllib uses simpler primitives
-    that work correctly after fork().
+    The session auth path uses urllib instead of httpx for synchronous authentication
+    requests. httpx is NOT fork-safe on macOS - creating httpx.Client after fork()
+    causes silent crashes due to OpenSSL threading issues. urllib uses simpler
+    primitives that work correctly after fork(). The API token path does not require
+    any network calls, so fork safety is not a concern.
 """
 
+import base64
+import json
+import logging
 import os
 from typing import Any
 
@@ -31,9 +44,17 @@ from nac_test.pyats_core.common.subprocess_auth import (
     execute_auth_subprocess,
 )
 
-# Default session lifetime for SDWAN Manager authentication in seconds
+logger = logging.getLogger(__name__)
+
+# Default session lifetime for SDWAN Manager session authentication in seconds
 # SDWAN Manager sessions are typically valid for 30 minutes (1800 seconds) by default
 SDWAN_MANAGER_SESSION_LIFETIME_SECONDS: int = 1800
+
+# Default cache lifetime for API token authentication in seconds
+# API tokens have their own expiration (set by admin), but we cache the decoded
+# result for 1 hour to avoid re-decoding on every test. The JWT itself is validated
+# server-side on each request, so an expired token will fail at request time.
+SDWAN_API_TOKEN_CACHE_LIFETIME_SECONDS: int = 3600
 
 # HTTP timeout for XSRF token fetch (shorter than auth timeout since it's optional)
 XSRF_TOKEN_FETCH_TIMEOUT_SECONDS: float = 10.0
@@ -167,7 +188,7 @@ if auth_body is not None:
             except Exception:
                 pass  # Pre-19.2 versions do not support XSRF tokens
 
-            result = {"jsessionid": jsessionid, "xsrf_token": xsrf_token}
+            result = {"jsessionid": jsessionid, "xsrf_token": xsrf_token, "auth_type": "session"}
 """
 
 
@@ -184,17 +205,25 @@ class SDWANManagerAuth:
        handling session renewal when expired. This is the primary method that consumers
        should use for obtaining SDWAN Manager authentication data.
 
-    The authentication flow supports both:
+    The authentication flow supports:
     - Pre-19.2 versions: JSESSIONID cookie only
     - 19.2+ versions: JSESSIONID cookie plus X-XSRF-TOKEN header for CSRF protection
+    - 20.18+ versions: API token (JWT) with Bearer authorization and X-XSRF-TOKEN
+
+    When SDWAN_API_TOKEN is set, token-based auth takes priority over
+    username/password credentials.
 
     Example:
-        >>> # Get authentication data for SDWAN Manager API calls
+        >>> # Session auth
         >>> auth_data = SDWANManagerAuth.get_auth()
-        >>> # Use in requests
         >>> headers = {"Cookie": f"JSESSIONID={auth_data['jsessionid']}"}
         >>> if auth_data.get("xsrf_token"):
         ...     headers["X-XSRF-TOKEN"] = auth_data["xsrf_token"]
+        >>>
+        >>> # Token auth (20.18+) — set SDWAN_API_TOKEN env var, then:
+        >>> auth_data = SDWANManagerAuth.get_auth()
+        >>> headers = {"Authorization": f"Bearer {auth_data['api_token']}"}
+        >>> headers["X-XSRF-TOKEN"] = auth_data["csrf_token"]
     """
 
     @staticmethod
@@ -253,7 +282,70 @@ class SDWANManagerAuth:
         return {
             "jsessionid": auth_result["jsessionid"],
             "xsrf_token": auth_result.get("xsrf_token"),
+            "auth_type": "session",
         }, SDWAN_MANAGER_SESSION_LIFETIME_SECONDS
+
+    @staticmethod
+    def _authenticate_with_api_token(
+        api_token: str,
+    ) -> tuple[dict[str, Any], int]:
+        """Authenticate using a pre-generated API token (JWT) for SD-WAN 20.18+.
+
+        This method decodes the JWT payload to extract the CSRF token without
+        making any network calls. The JWT is validated server-side on each API
+        request, so no upfront validation against the controller is performed.
+
+        The JWT payload is expected to contain a 'csrf' field. The token format
+        is: header.payload.signature (standard JWT structure).
+
+        Args:
+            api_token: The JWT API token string (e.g., from SDWAN_API_TOKEN
+                environment variable).
+
+        Returns:
+            A tuple containing:
+                - auth_dict (dict): Dictionary with 'api_token' (str),
+                  'csrf_token' (str), and 'auth_type' set to 'token'.
+                - expires_in (int): Cache lifetime in seconds.
+
+        Raises:
+            ValueError: If the token is not a valid JWT or is missing the
+                'csrf' field in its payload.
+        """
+        try:
+            parts = api_token.split(".")
+            if len(parts) != 3:  # noqa: PLR2004
+                raise ValueError(
+                    "SDWAN_API_TOKEN is not a valid JWT: expected 3 dot-separated "
+                    "parts (header.payload.signature), "
+                    f"got {len(parts)}."
+                )
+            payload_b64 = parts[1]
+            # Add padding for base64 decoding
+            payload_b64 += "=" * (-len(payload_b64) % 4)
+            payload = json.loads(base64.urlsafe_b64decode(payload_b64))
+        except (json.JSONDecodeError, UnicodeDecodeError, Exception) as e:
+            if isinstance(e, ValueError):
+                raise
+            raise ValueError(
+                "Failed to decode SDWAN_API_TOKEN: not a valid JWT. "
+                "Verify the token format (header.payload.signature)."
+            ) from e
+
+        csrf_token = payload.get("csrf", "")
+        if not csrf_token:
+            raise ValueError(
+                "SDWAN_API_TOKEN is missing 'csrf' field in JWT payload. "
+                "Verify the token was generated correctly."
+            )
+
+        logger.info("Using API token authentication (SD-WAN 20.18+)")
+
+        return {
+            "api_token": api_token,
+            "csrf_token": csrf_token,
+            "auth_type": "token",
+        }, SDWAN_API_TOKEN_CACHE_LIFETIME_SECONDS
 
     @classmethod
     def get_auth(cls) -> dict[str, Any]:
@@ -269,41 +361,61 @@ class SDWANManagerAuth:
         and URL to ensure proper session isolation between different SDWAN Manager
         instances.
 
-        Environment Variables Required:
-            SDWAN_URL: Base URL of the SDWAN Manager
-            SDWAN_USERNAME: SDWAN Manager username for authentication
-            SDWAN_PASSWORD: SDWAN Manager password for authentication
+        Environment Variables:
+            SDWAN_API_TOKEN: (Optional) JWT API token for 20.18+ token-based auth.
+                When set, takes priority over username/password. SDWAN_URL is still
+                required.
+            SDWAN_URL: Base URL of the SDWAN Manager (always required).
+            SDWAN_USERNAME: SDWAN Manager username (required for session auth).
+            SDWAN_PASSWORD: SDWAN Manager password (required for session auth).
             SDWAN_INSECURE: If "True", "1", or "yes" (default: "True"), SSL certificate
                 verification is disabled. Set to "False" to enable SSL verification.
+                Only used for session auth.
 
         Returns:
-            A dictionary containing:
-                - jsessionid (str): The session cookie value for API requests
-                - xsrf_token (str | None): The XSRF token for CSRF protection
-                  (None for pre-19.2 versions)
+            A dictionary containing auth data. The 'auth_type' key indicates the
+            method used:
+
+            For session auth (auth_type='session'):
+                - jsessionid (str): The session cookie value
+                - xsrf_token (str | None): The XSRF token (None for pre-19.2)
+                - auth_type (str): 'session'
+
+            For token auth (auth_type='token'):
+                - api_token (str): The Bearer token for Authorization header
+                - csrf_token (str): The CSRF token extracted from JWT payload
+                - auth_type (str): 'token'
 
         Raises:
-            ValueError: If any required environment variables (SDWAN_URL,
-                SDWAN_USERNAME, SDWAN_PASSWORD) are not set.
-            SubprocessAuthError: If authentication fails due to invalid credentials,
-                network issues, connection timeouts, or SDWAN Manager server errors.
-                The error message will contain details from the authentication
-                subprocess.
-
-        Example:
-            >>> # Set environment variables first
-            >>> import os
-            >>> os.environ["SDWAN_URL"] = "https://sdwan-manager.example.com"
-            >>> os.environ["SDWAN_USERNAME"] = "admin"
-            >>> os.environ["SDWAN_PASSWORD"] = "password123"
-            >>> # Get authentication data
-            >>> auth_data = SDWANManagerAuth.get_auth()
-            >>> # Use in API requests
-            >>> headers = {"Cookie": f"JSESSIONID={auth_data['jsessionid']}"}
-            >>> if auth_data.get("xsrf_token"):
-            ...     headers["X-XSRF-TOKEN"] = auth_data["xsrf_token"]
+            ValueError: If required environment variables are missing, or if
+                SDWAN_API_TOKEN is not a valid JWT / missing 'csrf' field.
+            SubprocessAuthError: If session authentication fails due to invalid
+                credentials, network issues, or server errors.
         """
         url = os.environ.get("SDWAN_URL")
+        api_token = os.environ.get("SDWAN_API_TOKEN", "").strip()
+
+        if not url:
+            raise ValueError(
+                "Missing required environment variable: SDWAN_URL"
+            )
+
+        # Normalize URL by removing trailing slash
+        url = url.rstrip("/")
+
+        # API token takes priority over username/password when both are set
+        if api_token:
+            def token_auth_wrapper() -> tuple[dict[str, Any], int]:
+                """Wrapper for API token authentication."""
+                return cls._authenticate_with_api_token(api_token)
+
+            return AuthCache.get_or_create(  # type: ignore[no-any-return]
+                controller_type="SDWAN_MANAGER_TOKEN",
+                url=url,
+                auth_func=token_auth_wrapper,
+            )
+
+        # Fall back to session-based authentication
         username = os.environ.get("SDWAN_USERNAME")
         password = os.environ.get("SDWAN_PASSWORD")
         insecure = os.environ.get("SDWAN_INSECURE", "True").lower() in (
@@ -312,20 +424,17 @@ class SDWANManagerAuth:
             "yes",
         )
 
-        if not all([url, username, password]):
+        if not all([username, password]):
             missing_vars: list[str] = []
-            if not url:
-                missing_vars.append("SDWAN_URL")
             if not username:
                 missing_vars.append("SDWAN_USERNAME")
             if not password:
                 missing_vars.append("SDWAN_PASSWORD")
             raise ValueError(
-                f"Missing required environment variables: {', '.join(missing_vars)}"
+                f"Missing required environment variables: {', '.join(missing_vars)}. "
+                "Provide SDWAN_API_TOKEN for token auth, or SDWAN_USERNAME and "
+                "SDWAN_PASSWORD for session auth."
             )
-
-        # Normalize URL by removing trailing slash
-        url = url.rstrip("/")  # type: ignore[union-attr]
 
         # SDWAN_INSECURE=True means verify_ssl=False
         verify_ssl = not insecure

--- a/src/nac_test_pyats_common/sdwan/auth.py
+++ b/src/nac_test_pyats_common/sdwan/auth.py
@@ -34,6 +34,7 @@ Note on Fork Safety:
 
 import base64
 import json
+import logging
 import os
 from typing import Any
 
@@ -42,6 +43,13 @@ from nac_test.pyats_core.common.subprocess_auth import (
     SubprocessAuthError,  # noqa: F401 - re-exported for callers to catch
     execute_auth_subprocess,
 )
+
+try:
+    from nac_test.utils.controller import get_matched_credential_set
+except ImportError:
+    get_matched_credential_set = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
 
 # Default session lifetime for SDWAN Manager authentication in seconds
 # SDWAN Manager sessions are typically valid for 30 minutes (1800 seconds) by default
@@ -330,11 +338,17 @@ class SDWANManagerAuth:
             'session'
             >>> headers = {"Cookie": f"JSESSIONID={auth_data['jsessionid']}"}
         """
-        from nac_test.utils.controller import get_matched_credential_set
-
         # Determine auth method from the credential set matched during detection
-        matched = get_matched_credential_set("SDWAN")
-        auth_method = matched.auth_method if matched else "session"
+        if get_matched_credential_set is not None:
+            matched = get_matched_credential_set("SDWAN")
+            auth_method = matched.auth_method if matched else "session"
+        else:
+            logger.warning(
+                "nac_test.utils.controller.get_matched_credential_set is not "
+                "available — falling back to session auth. This usually "
+                "indicates a nac-test version mismatch or incomplete installation."
+            )
+            auth_method = "session"
 
         if auth_method == "token":
             return cls._get_token_auth()

--- a/src/nac_test_pyats_common/sdwan/auth.py
+++ b/src/nac_test_pyats_common/sdwan/auth.py
@@ -404,16 +404,11 @@ class SDWANManagerAuth:
         url = url.rstrip("/")
 
         # API token takes priority over username/password when both are set
+        # No caching for API token auth — JWT decoding is cheap (no network call)
+        # and caching causes stale-token issues when the env var is updated.
         if api_token:
-            def token_auth_wrapper() -> tuple[dict[str, Any], int]:
-                """Wrapper for API token authentication."""
-                return cls._authenticate_with_api_token(api_token)
-
-            return AuthCache.get_or_create(  # type: ignore[no-any-return]
-                controller_type="SDWAN_MANAGER_TOKEN",
-                url=url,
-                auth_func=token_auth_wrapper,
-            )
+            auth_data, _ = cls._authenticate_with_api_token(api_token)
+            return auth_data
 
         # Fall back to session-based authentication
         username = os.environ.get("SDWAN_USERNAME")

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2025 Daniel Schmidt
+
+"""Shared fixtures for unit tests."""
+
+import os
+
+import pytest
+from _pytest.monkeypatch import MonkeyPatch
+
+CONTROLLER_ENV_PREFIXES = ("ACI_", "SDWAN_", "CC_", "MERAKI_", "FMC_", "ISE_", "IOSXE_")
+
+
+@pytest.fixture(autouse=True)
+def clean_controller_env(monkeypatch: MonkeyPatch) -> None:
+    """Clear all controller-related environment variables.
+
+    Ensures tests run in isolation regardless of the caller's shell environment.
+    """
+    for key in list(os.environ.keys()):
+        if any(key.startswith(prefix) for prefix in CONTROLLER_ENV_PREFIXES):
+            monkeypatch.delenv(key, raising=False)

--- a/tests/unit/sdwan/test_api_test_base.py
+++ b/tests/unit/sdwan/test_api_test_base.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2025 Daniel Schmidt
+
+"""Unit tests for SDWANManagerTestBase header construction.
+
+Tests that get_sdwan_manager_client() builds correct HTTP headers for:
+1. Token auth (Bearer + X-XSRF-TOKEN from JWT)
+2. Session auth with XSRF token (JSESSIONID cookie + X-XSRF-TOKEN)
+3. Session auth without XSRF token (JSESSIONID cookie only, pre-19.2)
+4. Unsupported auth_method raises ValueError
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from pytest_mock import MockerFixture
+
+from nac_test_pyats_common.sdwan.api_test_base import SDWANManagerTestBase
+
+
+@pytest.fixture
+def test_base(mocker: MockerFixture) -> SDWANManagerTestBase:
+    """Create a SDWANManagerTestBase instance with mocked internals."""
+    instance = SDWANManagerTestBase.__new__(SDWANManagerTestBase)
+    instance.controller_url = "https://sdwan.example.com"
+
+    # Mock pool.get_client to capture the headers passed to it
+    mock_pool = MagicMock()
+    mock_pool.get_client.return_value = MagicMock()
+    instance.pool = mock_pool
+
+    # Mock wrap_client_for_tracking to return the base client unchanged
+    instance.wrap_client_for_tracking = MagicMock(  # type: ignore[assignment]
+        side_effect=lambda client, **kw: client,
+    )
+
+    return instance
+
+
+class TestGetSDWANManagerClientHeaders:
+    """Test header construction in get_sdwan_manager_client()."""
+
+    def test_token_auth_headers(self, test_base: SDWANManagerTestBase) -> None:
+        """Token auth sets Bearer Authorization and X-XSRF-TOKEN from JWT."""
+        test_base.auth_data = {
+            "auth_method": "token",
+            "api_token": "my-jwt-token",
+            "csrf_token": "csrf-from-jwt",
+        }
+
+        test_base.get_sdwan_manager_client()
+
+        headers = test_base.pool.get_client.call_args.kwargs["headers"]
+        assert headers["Authorization"] == "Bearer my-jwt-token"
+        assert headers["X-XSRF-TOKEN"] == "csrf-from-jwt"
+        assert headers["Content-Type"] == "application/json"
+        assert "Cookie" not in headers
+
+    def test_session_auth_headers_with_xsrf(
+        self, test_base: SDWANManagerTestBase
+    ) -> None:
+        """Session auth sets JSESSIONID cookie and X-XSRF-TOKEN."""
+        test_base.auth_data = {
+            "auth_method": "session",
+            "jsessionid": "sess-abc123",
+            "xsrf_token": "xsrf-def456",
+        }
+
+        test_base.get_sdwan_manager_client()
+
+        headers = test_base.pool.get_client.call_args.kwargs["headers"]
+        assert headers["Cookie"] == "JSESSIONID=sess-abc123"
+        assert headers["X-XSRF-TOKEN"] == "xsrf-def456"
+        assert headers["Content-Type"] == "application/json"
+        assert "Authorization" not in headers
+
+    def test_session_auth_headers_without_xsrf(
+        self, test_base: SDWANManagerTestBase
+    ) -> None:
+        """Pre-19.2 session auth: JSESSIONID cookie only, no X-XSRF-TOKEN."""
+        test_base.auth_data = {
+            "auth_method": "session",
+            "jsessionid": "sess-old",
+            "xsrf_token": None,
+        }
+
+        test_base.get_sdwan_manager_client()
+
+        headers = test_base.pool.get_client.call_args.kwargs["headers"]
+        assert headers["Cookie"] == "JSESSIONID=sess-old"
+        assert "X-XSRF-TOKEN" not in headers
+
+    def test_unsupported_auth_method_raises(
+        self, test_base: SDWANManagerTestBase
+    ) -> None:
+        """Unknown auth_method raises ValueError."""
+        test_base.auth_data = {"auth_method": "kerberos"}
+
+        with pytest.raises(ValueError, match="Unsupported auth_method"):
+            test_base.get_sdwan_manager_client()

--- a/tests/unit/sdwan/test_auth.py
+++ b/tests/unit/sdwan/test_auth.py
@@ -28,6 +28,22 @@ from nac_test_pyats_common.sdwan.auth import (
 )
 
 # ---------------------------------------------------------------------------
+# Environment isolation — remove real SDWAN_* env vars so tests are hermetic
+# ---------------------------------------------------------------------------
+_SDWAN_ENV_VARS = [
+    "SDWAN_URL", "SDWAN_USERNAME", "SDWAN_PASSWORD",
+    "SDWAN_API_TOKEN", "SDWAN_INSECURE",
+]
+
+
+@pytest.fixture(autouse=True)
+def _clean_sdwan_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Remove all SDWAN_* env vars before each test for isolation."""
+    for var in _SDWAN_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+# ---------------------------------------------------------------------------
 # Shared test params used by script body execution tests
 # ---------------------------------------------------------------------------
 _BASE_PARAMS: dict[str, Any] = {

--- a/tests/unit/sdwan/test_auth.py
+++ b/tests/unit/sdwan/test_auth.py
@@ -12,6 +12,7 @@ Tests SD-WAN Manager authentication:
 5. Environment variable validation (missing credentials)
 6. URL normalization (trailing slash handling)
 7. Script body survival through _indent_script_body() transform
+8. API token authentication (20.18+) — JWT decode, CSRF extraction, priority
 """
 
 from io import BytesIO
@@ -518,3 +519,196 @@ class TestScriptBodyIndentSurvival:
         wrapper = f"try:\n{indented}\nexcept Exception:\n    pass\n"
         # compile() raises SyntaxError if the indented script is invalid
         compile(wrapper, "<indented_auth_script>", "exec")
+
+
+# ===========================================================================
+# Helper: build a valid JWT for API token tests
+# ===========================================================================
+
+def _make_jwt(payload: dict[str, Any], header: str = "eyJhbGciOiJIUzI1NiJ9") -> str:
+    """Build a JWT string from a payload dict (signature is a dummy)."""
+    import base64
+    import json
+
+    payload_bytes = json.dumps(payload).encode("utf-8")
+    payload_b64 = base64.urlsafe_b64encode(payload_bytes).rstrip(b"=").decode("ascii")
+    return f"{header}.{payload_b64}.dummy_signature"
+
+
+# ===========================================================================
+# 8. _authenticate_with_api_token() — JWT decode and CSRF extraction
+# ===========================================================================
+
+
+class TestAuthenticateWithApiToken:
+    """Test API token authentication (20.18+)."""
+
+    def test_valid_jwt_with_csrf(self) -> None:
+        """Valid JWT with csrf field returns api_token, csrf_token, auth_type."""
+        token = _make_jwt({"csrf": "abc123csrf", "sub": "admin"})
+
+        result, ttl = SDWANManagerAuth._authenticate_with_api_token(token)
+
+        assert result["api_token"] == token
+        assert result["csrf_token"] == "abc123csrf"
+        assert result["auth_type"] == "token"
+        assert ttl == 3600
+
+    def test_jwt_missing_csrf_raises_error(self) -> None:
+        """JWT without 'csrf' field raises ValueError."""
+        token = _make_jwt({"sub": "admin", "exp": 9999999999})
+
+        with pytest.raises(ValueError) as exc_info:
+            SDWANManagerAuth._authenticate_with_api_token(token)
+
+        assert "missing 'csrf' field" in str(exc_info.value)
+
+    def test_jwt_empty_csrf_raises_error(self) -> None:
+        """JWT with empty 'csrf' field raises ValueError."""
+        token = _make_jwt({"csrf": "", "sub": "admin"})
+
+        with pytest.raises(ValueError) as exc_info:
+            SDWANManagerAuth._authenticate_with_api_token(token)
+
+        assert "missing 'csrf' field" in str(exc_info.value)
+
+    def test_not_a_jwt_raises_error(self) -> None:
+        """Non-JWT string raises ValueError."""
+        with pytest.raises(ValueError) as exc_info:
+            SDWANManagerAuth._authenticate_with_api_token("not-a-jwt")
+
+        assert "not a valid JWT" in str(exc_info.value)
+        assert "got 1" in str(exc_info.value)
+
+    def test_two_part_token_raises_error(self) -> None:
+        """Token with only 2 parts raises ValueError."""
+        with pytest.raises(ValueError) as exc_info:
+            SDWANManagerAuth._authenticate_with_api_token("header.payload")
+
+        assert "got 2" in str(exc_info.value)
+
+    def test_invalid_base64_payload_raises_error(self) -> None:
+        """JWT with corrupt base64 payload raises ValueError."""
+        with pytest.raises(ValueError) as exc_info:
+            SDWANManagerAuth._authenticate_with_api_token("header.!!!invalid!!!.sig")
+
+        assert "not a valid JWT" in str(exc_info.value)
+
+    def test_invalid_json_payload_raises_error(self) -> None:
+        """JWT with valid base64 but invalid JSON payload raises ValueError."""
+        import base64
+
+        bad_payload = base64.urlsafe_b64encode(b"not json").rstrip(b"=").decode()
+        token = f"header.{bad_payload}.sig"
+
+        with pytest.raises(ValueError) as exc_info:
+            SDWANManagerAuth._authenticate_with_api_token(token)
+
+        assert "not a valid JWT" in str(exc_info.value)
+
+
+# ===========================================================================
+# 9. get_auth() — API token priority and env var handling
+# ===========================================================================
+
+
+class TestGetAuthApiTokenPriority:
+    """Test that SDWAN_API_TOKEN takes priority over username/password."""
+
+    def test_api_token_used_when_set(
+        self, mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """SDWAN_API_TOKEN takes priority over username/password."""
+        token = _make_jwt({"csrf": "my-csrf"})
+        monkeypatch.setenv("SDWAN_URL", "https://sdwan.example.com")
+        monkeypatch.setenv("SDWAN_API_TOKEN", token)
+        monkeypatch.setenv("SDWAN_USERNAME", "admin")
+        monkeypatch.setenv("SDWAN_PASSWORD", "password123")
+
+        mock_cache = mocker.patch(
+            "nac_test_pyats_common.sdwan.auth.AuthCache.get_or_create"
+        )
+        mock_cache.return_value = {
+            "api_token": token,
+            "csrf_token": "my-csrf",
+            "auth_type": "token",
+        }
+
+        result = SDWANManagerAuth.get_auth()
+
+        assert result["auth_type"] == "token"
+        call_kwargs = mock_cache.call_args.kwargs
+        assert call_kwargs["controller_type"] == "SDWAN_MANAGER_TOKEN"
+
+    def test_session_auth_fallback_when_no_token(
+        self, mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Falls back to session auth when SDWAN_API_TOKEN is not set."""
+        monkeypatch.setenv("SDWAN_URL", "https://sdwan.example.com")
+        monkeypatch.setenv("SDWAN_USERNAME", "admin")
+        monkeypatch.setenv("SDWAN_PASSWORD", "password123")
+
+        mock_cache = mocker.patch(
+            "nac_test_pyats_common.sdwan.auth.AuthCache.get_or_create"
+        )
+        mock_cache.return_value = {
+            "jsessionid": "sess-abc",
+            "xsrf_token": "tok-xyz",
+            "auth_type": "session",
+        }
+
+        result = SDWANManagerAuth.get_auth()
+
+        assert result["auth_type"] == "session"
+        call_kwargs = mock_cache.call_args.kwargs
+        assert call_kwargs["controller_type"] == "SDWAN_MANAGER"
+
+    def test_missing_url_raises_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Missing SDWAN_URL raises ValueError even with API token."""
+        token = _make_jwt({"csrf": "my-csrf"})
+        monkeypatch.setenv("SDWAN_API_TOKEN", token)
+
+        with pytest.raises(ValueError) as exc_info:
+            SDWANManagerAuth.get_auth()
+
+        assert "SDWAN_URL" in str(exc_info.value)
+
+    def test_missing_creds_without_token_shows_hint(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Missing username/password without token gives helpful error message."""
+        monkeypatch.setenv("SDWAN_URL", "https://sdwan.example.com")
+
+        with pytest.raises(ValueError) as exc_info:
+            SDWANManagerAuth.get_auth()
+
+        error_msg = str(exc_info.value)
+        assert "SDWAN_USERNAME" in error_msg
+        assert "SDWAN_PASSWORD" in error_msg
+        assert "SDWAN_API_TOKEN" in error_msg
+
+    def test_empty_api_token_falls_back_to_session(
+        self, mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Empty/whitespace SDWAN_API_TOKEN falls back to session auth."""
+        monkeypatch.setenv("SDWAN_URL", "https://sdwan.example.com")
+        monkeypatch.setenv("SDWAN_API_TOKEN", "  ")
+        monkeypatch.setenv("SDWAN_USERNAME", "admin")
+        monkeypatch.setenv("SDWAN_PASSWORD", "password123")
+
+        mock_cache = mocker.patch(
+            "nac_test_pyats_common.sdwan.auth.AuthCache.get_or_create"
+        )
+        mock_cache.return_value = {
+            "jsessionid": "sess",
+            "xsrf_token": None,
+            "auth_type": "session",
+        }
+
+        result = SDWANManagerAuth.get_auth()
+
+        assert result["auth_type"] == "session"
+        call_kwargs = mock_cache.call_args.kwargs
+        assert call_kwargs["controller_type"] == "SDWAN_MANAGER"

--- a/tests/unit/sdwan/test_auth.py
+++ b/tests/unit/sdwan/test_auth.py
@@ -15,9 +15,9 @@ Tests SD-WAN Manager authentication:
 8. Token auth path — get_matched_credential_set() integration
 """
 
+from dataclasses import dataclass
 from io import BytesIO
 from typing import Any
-from dataclasses import dataclass
 from unittest.mock import MagicMock
 
 import pytest
@@ -39,6 +39,7 @@ except ImportError:
         env_vars: tuple[str, ...]
         label: str
         auth_method: str = "session"
+
 
 # ---------------------------------------------------------------------------
 # Shared test params used by script body execution tests

--- a/tests/unit/sdwan/test_auth.py
+++ b/tests/unit/sdwan/test_auth.py
@@ -425,6 +425,8 @@ class TestGetAuthEnvironmentValidation:
 
     def test_get_auth_missing_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Error when SDWAN_URL is missing."""
+        monkeypatch.delenv("SDWAN_URL", raising=False)
+        monkeypatch.delenv("SDWAN_API_TOKEN", raising=False)
         monkeypatch.setenv("SDWAN_USERNAME", "admin")
         monkeypatch.setenv("SDWAN_PASSWORD", "password123")
 
@@ -436,6 +438,7 @@ class TestGetAuthEnvironmentValidation:
 
     def test_get_auth_missing_username(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Error when SDWAN_USERNAME is missing."""
+        monkeypatch.delenv("SDWAN_API_TOKEN", raising=False)
         monkeypatch.setenv("SDWAN_URL", "https://sdwan.example.com")
         monkeypatch.setenv("SDWAN_PASSWORD", "password123")
 
@@ -446,6 +449,7 @@ class TestGetAuthEnvironmentValidation:
 
     def test_get_auth_missing_password(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Error when SDWAN_PASSWORD is missing."""
+        monkeypatch.delenv("SDWAN_API_TOKEN", raising=False)
         monkeypatch.setenv("SDWAN_URL", "https://sdwan.example.com")
         monkeypatch.setenv("SDWAN_USERNAME", "admin")
 
@@ -458,6 +462,11 @@ class TestGetAuthEnvironmentValidation:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Error message includes all missing variables."""
+        monkeypatch.delenv("SDWAN_URL", raising=False)
+        monkeypatch.delenv("SDWAN_API_TOKEN", raising=False)
+        monkeypatch.delenv("SDWAN_USERNAME", raising=False)
+        monkeypatch.delenv("SDWAN_PASSWORD", raising=False)
+
         with pytest.raises(ValueError) as exc_info:
             SDWANManagerAuth.get_auth()
 
@@ -528,14 +537,23 @@ class TestScriptBodyIndentSurvival:
 class TestTokenAuth:
     """Test token-based authentication path (SD-WAN Manager 20.18+)."""
 
-    def test_token_auth_returns_api_token(
+    # Valid JWT with csrf field in payload for testing.
+    # Payload: {"sub": "admin", "csrf": "DEADBEEF1234", "isAPIKey": true}
+    VALID_JWT = (
+        "eyJ0eXAiOiJqd3QiLCJhbGciOiJSUzI1NiJ9"
+        ".eyJzdWIiOiJhZG1pbiIsImNzcmYiOiJERUFEQkVFRjEyMzQiLCJpc0FQSUtleSI6dHJ1ZX0"
+        ".fake-signature"
+    )
+    EXPECTED_CSRF = "DEADBEEF1234"
+
+    def test_token_auth_returns_api_token_and_csrf(
         self, mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """When auth_method=token, returns api_token directly without login."""
+        """When auth_method=token, returns api_token and csrf_token from JWT."""
         from nac_test.utils.controller import CredentialSet
 
         monkeypatch.setenv("SDWAN_URL", "https://sdwan.example.com")
-        monkeypatch.setenv("SDWAN_API_TOKEN", "my-secret-token")
+        monkeypatch.setenv("SDWAN_API_TOKEN", self.VALID_JWT)
 
         mock_matched = mocker.patch(
             "nac_test.utils.controller.get_matched_credential_set"
@@ -549,7 +567,8 @@ class TestTokenAuth:
         result = SDWANManagerAuth.get_auth()
 
         assert result["auth_method"] == "token"
-        assert result["api_token"] == "my-secret-token"
+        assert result["api_token"] == self.VALID_JWT
+        assert result["csrf_token"] == self.EXPECTED_CSRF
 
     def test_token_auth_missing_token_raises(
         self, mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
@@ -558,6 +577,7 @@ class TestTokenAuth:
         from nac_test.utils.controller import CredentialSet
 
         monkeypatch.setenv("SDWAN_URL", "https://sdwan.example.com")
+        monkeypatch.delenv("SDWAN_API_TOKEN", raising=False)
 
         mock_matched = mocker.patch(
             "nac_test.utils.controller.get_matched_credential_set"
@@ -579,6 +599,7 @@ class TestTokenAuth:
         """Error when SDWAN_URL is missing in token mode."""
         from nac_test.utils.controller import CredentialSet
 
+        monkeypatch.delenv("SDWAN_URL", raising=False)
         monkeypatch.setenv("SDWAN_API_TOKEN", "my-secret-token")
 
         mock_matched = mocker.patch(
@@ -602,7 +623,7 @@ class TestTokenAuth:
         from nac_test.utils.controller import CredentialSet
 
         monkeypatch.setenv("SDWAN_URL", "https://sdwan.example.com")
-        monkeypatch.setenv("SDWAN_API_TOKEN", "my-secret-token")
+        monkeypatch.setenv("SDWAN_API_TOKEN", self.VALID_JWT)
 
         mock_matched = mocker.patch(
             "nac_test.utils.controller.get_matched_credential_set"
@@ -624,6 +645,59 @@ class TestTokenAuth:
 
         mock_cache.assert_not_called()
         mock_subprocess.assert_not_called()
+
+    def test_token_auth_invalid_jwt_raises(
+        self, mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Error when SDWAN_API_TOKEN is not a valid JWT (no dots)."""
+        from nac_test.utils.controller import CredentialSet
+
+        monkeypatch.setenv("SDWAN_URL", "https://sdwan.example.com")
+        monkeypatch.setenv("SDWAN_API_TOKEN", "not-a-jwt")
+
+        mock_matched = mocker.patch(
+            "nac_test.utils.controller.get_matched_credential_set"
+        )
+        mock_matched.return_value = CredentialSet(
+            env_vars=["SDWAN_URL", "SDWAN_API_TOKEN"],
+            label="API Token (20.18+)",
+            auth_method="token",
+        )
+
+        with pytest.raises(ValueError, match="not a valid JWT"):
+            SDWANManagerAuth.get_auth()
+
+    def test_token_auth_missing_csrf_raises(
+        self, mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Error when JWT payload has no 'csrf' field."""
+        import base64
+        import json
+
+        from nac_test.utils.controller import CredentialSet
+
+        # JWT with payload {"sub": "admin"} — no csrf field
+        payload = (
+            base64.urlsafe_b64encode(json.dumps({"sub": "admin"}).encode())
+            .decode()
+            .rstrip("=")
+        )
+        no_csrf_jwt = f"eyJhbGciOiJSUzI1NiJ9.{payload}.fake-sig"
+
+        monkeypatch.setenv("SDWAN_URL", "https://sdwan.example.com")
+        monkeypatch.setenv("SDWAN_API_TOKEN", no_csrf_jwt)
+
+        mock_matched = mocker.patch(
+            "nac_test.utils.controller.get_matched_credential_set"
+        )
+        mock_matched.return_value = CredentialSet(
+            env_vars=["SDWAN_URL", "SDWAN_API_TOKEN"],
+            label="API Token (20.18+)",
+            auth_method="token",
+        )
+
+        with pytest.raises(ValueError, match="missing 'csrf' field"):
+            SDWANManagerAuth.get_auth()
 
     def test_session_auth_when_no_matched_credential_set(
         self, mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/sdwan/test_auth.py
+++ b/tests/unit/sdwan/test_auth.py
@@ -546,23 +546,27 @@ class TestTokenAuth:
     )
     EXPECTED_CSRF = "DEADBEEF1234"
 
-    def test_token_auth_returns_api_token_and_csrf(
-        self, mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """When auth_method=token, returns api_token and csrf_token from JWT."""
+    @pytest.fixture
+    def mock_credential_set(self, mocker: MockerFixture) -> MagicMock:
+        """Patch get_matched_credential_set with token auth CredentialSet."""
         from nac_test.utils.controller import CredentialSet
 
-        monkeypatch.setenv("SDWAN_URL", "https://sdwan.example.com")
-        monkeypatch.setenv("SDWAN_API_TOKEN", self.VALID_JWT)
-
-        mock_matched = mocker.patch(
+        mock = mocker.patch(
             "nac_test.utils.controller.get_matched_credential_set"
         )
-        mock_matched.return_value = CredentialSet(
+        mock.return_value = CredentialSet(
             env_vars=("SDWAN_URL", "SDWAN_API_TOKEN"),
             label="API Token (20.18+)",
             auth_method="token",
         )
+        return mock
+
+    def test_token_auth_returns_api_token_and_csrf(
+        self, mock_credential_set: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When auth_method=token, returns api_token and csrf_token from JWT."""
+        monkeypatch.setenv("SDWAN_URL", "https://sdwan.example.com")
+        monkeypatch.setenv("SDWAN_API_TOKEN", self.VALID_JWT)
 
         result = SDWANManagerAuth.get_auth()
 
@@ -571,22 +575,11 @@ class TestTokenAuth:
         assert result["csrf_token"] == self.EXPECTED_CSRF
 
     def test_token_auth_missing_token_raises(
-        self, mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
+        self, mock_credential_set: MagicMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Error when SDWAN_API_TOKEN is missing in token mode."""
-        from nac_test.utils.controller import CredentialSet
-
         monkeypatch.setenv("SDWAN_URL", "https://sdwan.example.com")
         monkeypatch.delenv("SDWAN_API_TOKEN", raising=False)
-
-        mock_matched = mocker.patch(
-            "nac_test.utils.controller.get_matched_credential_set"
-        )
-        mock_matched.return_value = CredentialSet(
-            env_vars=("SDWAN_URL", "SDWAN_API_TOKEN"),
-            label="API Token (20.18+)",
-            auth_method="token",
-        )
 
         with pytest.raises(ValueError) as exc_info:
             SDWANManagerAuth.get_auth()
@@ -594,22 +587,11 @@ class TestTokenAuth:
         assert "SDWAN_API_TOKEN" in str(exc_info.value)
 
     def test_token_auth_missing_url_raises(
-        self, mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
+        self, mock_credential_set: MagicMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Error when SDWAN_URL is missing in token mode."""
-        from nac_test.utils.controller import CredentialSet
-
         monkeypatch.delenv("SDWAN_URL", raising=False)
         monkeypatch.setenv("SDWAN_API_TOKEN", "my-secret-token")
-
-        mock_matched = mocker.patch(
-            "nac_test.utils.controller.get_matched_credential_set"
-        )
-        mock_matched.return_value = CredentialSet(
-            env_vars=("SDWAN_URL", "SDWAN_API_TOKEN"),
-            label="API Token (20.18+)",
-            auth_method="token",
-        )
 
         with pytest.raises(ValueError) as exc_info:
             SDWANManagerAuth.get_auth()
@@ -617,22 +599,14 @@ class TestTokenAuth:
         assert "SDWAN_URL" in str(exc_info.value)
 
     def test_token_auth_no_subprocess_call(
-        self, mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
+        self,
+        mocker: MockerFixture,
+        mock_credential_set: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Token auth does NOT invoke subprocess or AuthCache."""
-        from nac_test.utils.controller import CredentialSet
-
         monkeypatch.setenv("SDWAN_URL", "https://sdwan.example.com")
         monkeypatch.setenv("SDWAN_API_TOKEN", self.VALID_JWT)
-
-        mock_matched = mocker.patch(
-            "nac_test.utils.controller.get_matched_credential_set"
-        )
-        mock_matched.return_value = CredentialSet(
-            env_vars=("SDWAN_URL", "SDWAN_API_TOKEN"),
-            label="API Token (20.18+)",
-            auth_method="token",
-        )
 
         mock_cache = mocker.patch(
             "nac_test_pyats_common.sdwan.auth.AuthCache.get_or_create"
@@ -647,34 +621,21 @@ class TestTokenAuth:
         mock_subprocess.assert_not_called()
 
     def test_token_auth_invalid_jwt_raises(
-        self, mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
+        self, mock_credential_set: MagicMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Error when SDWAN_API_TOKEN is not a valid JWT (no dots)."""
-        from nac_test.utils.controller import CredentialSet
-
         monkeypatch.setenv("SDWAN_URL", "https://sdwan.example.com")
         monkeypatch.setenv("SDWAN_API_TOKEN", "not-a-jwt")
-
-        mock_matched = mocker.patch(
-            "nac_test.utils.controller.get_matched_credential_set"
-        )
-        mock_matched.return_value = CredentialSet(
-            env_vars=("SDWAN_URL", "SDWAN_API_TOKEN"),
-            label="API Token (20.18+)",
-            auth_method="token",
-        )
 
         with pytest.raises(ValueError, match="not a valid JWT"):
             SDWANManagerAuth.get_auth()
 
     def test_token_auth_missing_csrf_raises(
-        self, mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
+        self, mock_credential_set: MagicMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Error when JWT payload has no 'csrf' field."""
         import base64
         import json
-
-        from nac_test.utils.controller import CredentialSet
 
         # JWT with payload {"sub": "admin"} — no csrf field
         payload = (
@@ -687,30 +648,21 @@ class TestTokenAuth:
         monkeypatch.setenv("SDWAN_URL", "https://sdwan.example.com")
         monkeypatch.setenv("SDWAN_API_TOKEN", no_csrf_jwt)
 
-        mock_matched = mocker.patch(
-            "nac_test.utils.controller.get_matched_credential_set"
-        )
-        mock_matched.return_value = CredentialSet(
-            env_vars=("SDWAN_URL", "SDWAN_API_TOKEN"),
-            label="API Token (20.18+)",
-            auth_method="token",
-        )
-
         with pytest.raises(ValueError, match="missing 'csrf' field"):
             SDWANManagerAuth.get_auth()
 
     def test_session_auth_when_no_matched_credential_set(
-        self, mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
+        self,
+        mocker: MockerFixture,
+        mock_credential_set: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Falls back to session auth when get_matched_credential_set returns None."""
+        mock_credential_set.return_value = None
+
         monkeypatch.setenv("SDWAN_URL", "https://sdwan.example.com")
         monkeypatch.setenv("SDWAN_USERNAME", "admin")
         monkeypatch.setenv("SDWAN_PASSWORD", "password123")
-
-        mock_matched = mocker.patch(
-            "nac_test.utils.controller.get_matched_credential_set"
-        )
-        mock_matched.return_value = None
 
         mock_cache = mocker.patch(
             "nac_test_pyats_common.sdwan.auth.AuthCache.get_or_create"
@@ -725,23 +677,23 @@ class TestTokenAuth:
         mock_cache.assert_called_once()
 
     def test_session_auth_includes_auth_method_key(
-        self, mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
+        self,
+        mocker: MockerFixture,
+        mock_credential_set: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Session auth result includes auth_method='session'."""
         from nac_test.utils.controller import CredentialSet
 
-        monkeypatch.setenv("SDWAN_URL", "https://sdwan.example.com")
-        monkeypatch.setenv("SDWAN_USERNAME", "admin")
-        monkeypatch.setenv("SDWAN_PASSWORD", "password123")
-
-        mock_matched = mocker.patch(
-            "nac_test.utils.controller.get_matched_credential_set"
-        )
-        mock_matched.return_value = CredentialSet(
+        mock_credential_set.return_value = CredentialSet(
             env_vars=("SDWAN_URL", "SDWAN_USERNAME", "SDWAN_PASSWORD"),
             label="Username/Password",
             auth_method="session",
         )
+
+        monkeypatch.setenv("SDWAN_URL", "https://sdwan.example.com")
+        monkeypatch.setenv("SDWAN_USERNAME", "admin")
+        monkeypatch.setenv("SDWAN_PASSWORD", "password123")
 
         mock_cache = mocker.patch(
             "nac_test_pyats_common.sdwan.auth.AuthCache.get_or_create"

--- a/tests/unit/sdwan/test_auth.py
+++ b/tests/unit/sdwan/test_auth.py
@@ -17,6 +17,7 @@ Tests SD-WAN Manager authentication:
 
 from io import BytesIO
 from typing import Any
+from dataclasses import dataclass
 from unittest.mock import MagicMock
 
 import pytest
@@ -26,6 +27,18 @@ from nac_test_pyats_common.sdwan.auth import (
     _AUTH_SCRIPT_BODY,
     SDWANManagerAuth,
 )
+
+try:
+    from nac_test.utils.controller import CredentialSet
+except ImportError:
+    # Fallback for CI pipelines where nac-test hasn't been updated yet.
+    # Tests only need an object with the same attributes as CredentialSet;
+    # get_matched_credential_set() is fully mocked so the real class isn't required.
+    @dataclass(frozen=True)
+    class CredentialSet:  # type: ignore[no-redef]
+        env_vars: tuple[str, ...]
+        label: str
+        auth_method: str = "session"
 
 # ---------------------------------------------------------------------------
 # Shared test params used by script body execution tests
@@ -550,8 +563,6 @@ class TestTokenAuth:
     @pytest.fixture
     def mock_credential_set(self, mocker: MockerFixture) -> MagicMock:
         """Patch get_matched_credential_set with token auth CredentialSet."""
-        from nac_test.utils.controller import CredentialSet
-
         mock = mocker.patch(
             "nac_test_pyats_common.sdwan.auth.get_matched_credential_set"
         )
@@ -684,8 +695,6 @@ class TestTokenAuth:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Session auth result includes auth_method='session'."""
-        from nac_test.utils.controller import CredentialSet
-
         mock_credential_set.return_value = CredentialSet(
             env_vars=("SDWAN_URL", "SDWAN_USERNAME", "SDWAN_PASSWORD"),
             label="Username/Password",

--- a/tests/unit/sdwan/test_auth.py
+++ b/tests/unit/sdwan/test_auth.py
@@ -12,6 +12,7 @@ Tests SD-WAN Manager authentication:
 5. Environment variable validation (missing credentials)
 6. URL normalization (trailing slash handling)
 7. Script body survival through _indent_script_body() transform
+8. Token auth path — get_matched_credential_set() integration
 """
 
 from io import BytesIO

--- a/tests/unit/sdwan/test_auth.py
+++ b/tests/unit/sdwan/test_auth.py
@@ -518,3 +518,163 @@ class TestScriptBodyIndentSurvival:
         wrapper = f"try:\n{indented}\nexcept Exception:\n    pass\n"
         # compile() raises SyntaxError if the indented script is invalid
         compile(wrapper, "<indented_auth_script>", "exec")
+
+
+# ===========================================================================
+# 8. Token auth path — get_matched_credential_set() integration
+# ===========================================================================
+
+
+class TestTokenAuth:
+    """Test token-based authentication path (SD-WAN Manager 20.18+)."""
+
+    def test_token_auth_returns_api_token(
+        self, mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When auth_method=token, returns api_token directly without login."""
+        from nac_test.utils.controller import CredentialSet
+
+        monkeypatch.setenv("SDWAN_URL", "https://sdwan.example.com")
+        monkeypatch.setenv("SDWAN_API_TOKEN", "my-secret-token")
+
+        mock_matched = mocker.patch(
+            "nac_test.utils.controller.get_matched_credential_set"
+        )
+        mock_matched.return_value = CredentialSet(
+            env_vars=["SDWAN_URL", "SDWAN_API_TOKEN"],
+            label="API Token (20.18+)",
+            auth_method="token",
+        )
+
+        result = SDWANManagerAuth.get_auth()
+
+        assert result["auth_method"] == "token"
+        assert result["api_token"] == "my-secret-token"
+
+    def test_token_auth_missing_token_raises(
+        self, mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Error when SDWAN_API_TOKEN is missing in token mode."""
+        from nac_test.utils.controller import CredentialSet
+
+        monkeypatch.setenv("SDWAN_URL", "https://sdwan.example.com")
+
+        mock_matched = mocker.patch(
+            "nac_test.utils.controller.get_matched_credential_set"
+        )
+        mock_matched.return_value = CredentialSet(
+            env_vars=["SDWAN_URL", "SDWAN_API_TOKEN"],
+            label="API Token (20.18+)",
+            auth_method="token",
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            SDWANManagerAuth.get_auth()
+
+        assert "SDWAN_API_TOKEN" in str(exc_info.value)
+
+    def test_token_auth_missing_url_raises(
+        self, mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Error when SDWAN_URL is missing in token mode."""
+        from nac_test.utils.controller import CredentialSet
+
+        monkeypatch.setenv("SDWAN_API_TOKEN", "my-secret-token")
+
+        mock_matched = mocker.patch(
+            "nac_test.utils.controller.get_matched_credential_set"
+        )
+        mock_matched.return_value = CredentialSet(
+            env_vars=["SDWAN_URL", "SDWAN_API_TOKEN"],
+            label="API Token (20.18+)",
+            auth_method="token",
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            SDWANManagerAuth.get_auth()
+
+        assert "SDWAN_URL" in str(exc_info.value)
+
+    def test_token_auth_no_subprocess_call(
+        self, mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Token auth does NOT invoke subprocess or AuthCache."""
+        from nac_test.utils.controller import CredentialSet
+
+        monkeypatch.setenv("SDWAN_URL", "https://sdwan.example.com")
+        monkeypatch.setenv("SDWAN_API_TOKEN", "my-secret-token")
+
+        mock_matched = mocker.patch(
+            "nac_test.utils.controller.get_matched_credential_set"
+        )
+        mock_matched.return_value = CredentialSet(
+            env_vars=["SDWAN_URL", "SDWAN_API_TOKEN"],
+            label="API Token (20.18+)",
+            auth_method="token",
+        )
+
+        mock_cache = mocker.patch(
+            "nac_test_pyats_common.sdwan.auth.AuthCache.get_or_create"
+        )
+        mock_subprocess = mocker.patch(
+            "nac_test_pyats_common.sdwan.auth.execute_auth_subprocess"
+        )
+
+        SDWANManagerAuth.get_auth()
+
+        mock_cache.assert_not_called()
+        mock_subprocess.assert_not_called()
+
+    def test_session_auth_when_no_matched_credential_set(
+        self, mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Falls back to session auth when get_matched_credential_set returns None."""
+        monkeypatch.setenv("SDWAN_URL", "https://sdwan.example.com")
+        monkeypatch.setenv("SDWAN_USERNAME", "admin")
+        monkeypatch.setenv("SDWAN_PASSWORD", "password123")
+
+        mock_matched = mocker.patch(
+            "nac_test.utils.controller.get_matched_credential_set"
+        )
+        mock_matched.return_value = None
+
+        mock_cache = mocker.patch(
+            "nac_test_pyats_common.sdwan.auth.AuthCache.get_or_create"
+        )
+        mock_cache.return_value = {"jsessionid": "sess-123", "xsrf_token": "xsrf-abc"}
+
+        result = SDWANManagerAuth.get_auth()
+
+        assert result["auth_method"] == "session"
+        assert result["jsessionid"] == "sess-123"
+        assert result["xsrf_token"] == "xsrf-abc"
+        mock_cache.assert_called_once()
+
+    def test_session_auth_includes_auth_method_key(
+        self, mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Session auth result includes auth_method='session'."""
+        from nac_test.utils.controller import CredentialSet
+
+        monkeypatch.setenv("SDWAN_URL", "https://sdwan.example.com")
+        monkeypatch.setenv("SDWAN_USERNAME", "admin")
+        monkeypatch.setenv("SDWAN_PASSWORD", "password123")
+
+        mock_matched = mocker.patch(
+            "nac_test.utils.controller.get_matched_credential_set"
+        )
+        mock_matched.return_value = CredentialSet(
+            env_vars=["SDWAN_URL", "SDWAN_USERNAME", "SDWAN_PASSWORD"],
+            label="Username/Password",
+            auth_method="session",
+        )
+
+        mock_cache = mocker.patch(
+            "nac_test_pyats_common.sdwan.auth.AuthCache.get_or_create"
+        )
+        mock_cache.return_value = {"jsessionid": "sess-456", "xsrf_token": None}
+
+        result = SDWANManagerAuth.get_auth()
+
+        assert result["auth_method"] == "session"
+        assert result["jsessionid"] == "sess-456"

--- a/tests/unit/sdwan/test_auth.py
+++ b/tests/unit/sdwan/test_auth.py
@@ -559,7 +559,7 @@ class TestTokenAuth:
             "nac_test.utils.controller.get_matched_credential_set"
         )
         mock_matched.return_value = CredentialSet(
-            env_vars=["SDWAN_URL", "SDWAN_API_TOKEN"],
+            env_vars=("SDWAN_URL", "SDWAN_API_TOKEN"),
             label="API Token (20.18+)",
             auth_method="token",
         )
@@ -583,7 +583,7 @@ class TestTokenAuth:
             "nac_test.utils.controller.get_matched_credential_set"
         )
         mock_matched.return_value = CredentialSet(
-            env_vars=["SDWAN_URL", "SDWAN_API_TOKEN"],
+            env_vars=("SDWAN_URL", "SDWAN_API_TOKEN"),
             label="API Token (20.18+)",
             auth_method="token",
         )
@@ -606,7 +606,7 @@ class TestTokenAuth:
             "nac_test.utils.controller.get_matched_credential_set"
         )
         mock_matched.return_value = CredentialSet(
-            env_vars=["SDWAN_URL", "SDWAN_API_TOKEN"],
+            env_vars=("SDWAN_URL", "SDWAN_API_TOKEN"),
             label="API Token (20.18+)",
             auth_method="token",
         )
@@ -629,7 +629,7 @@ class TestTokenAuth:
             "nac_test.utils.controller.get_matched_credential_set"
         )
         mock_matched.return_value = CredentialSet(
-            env_vars=["SDWAN_URL", "SDWAN_API_TOKEN"],
+            env_vars=("SDWAN_URL", "SDWAN_API_TOKEN"),
             label="API Token (20.18+)",
             auth_method="token",
         )
@@ -659,7 +659,7 @@ class TestTokenAuth:
             "nac_test.utils.controller.get_matched_credential_set"
         )
         mock_matched.return_value = CredentialSet(
-            env_vars=["SDWAN_URL", "SDWAN_API_TOKEN"],
+            env_vars=("SDWAN_URL", "SDWAN_API_TOKEN"),
             label="API Token (20.18+)",
             auth_method="token",
         )
@@ -691,7 +691,7 @@ class TestTokenAuth:
             "nac_test.utils.controller.get_matched_credential_set"
         )
         mock_matched.return_value = CredentialSet(
-            env_vars=["SDWAN_URL", "SDWAN_API_TOKEN"],
+            env_vars=("SDWAN_URL", "SDWAN_API_TOKEN"),
             label="API Token (20.18+)",
             auth_method="token",
         )
@@ -738,7 +738,7 @@ class TestTokenAuth:
             "nac_test.utils.controller.get_matched_credential_set"
         )
         mock_matched.return_value = CredentialSet(
-            env_vars=["SDWAN_URL", "SDWAN_USERNAME", "SDWAN_PASSWORD"],
+            env_vars=("SDWAN_URL", "SDWAN_USERNAME", "SDWAN_PASSWORD"),
             label="Username/Password",
             auth_method="session",
         )

--- a/tests/unit/sdwan/test_auth.py
+++ b/tests/unit/sdwan/test_auth.py
@@ -558,7 +558,7 @@ class TestTokenAuth:
             label="API Token (20.18+)",
             auth_method="token",
         )
-        return mock
+        return mock  # type: ignore[no-any-return]
 
     def test_token_auth_returns_api_token_and_csrf(
         self, mock_credential_set: MagicMock, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/sdwan/test_auth.py
+++ b/tests/unit/sdwan/test_auth.py
@@ -395,7 +395,11 @@ class TestAuthenticateMethod:
             verify_ssl=False,
         )
 
-        assert result == {"jsessionid": "sess-abc", "xsrf_token": "token-xyz"}
+        assert result == {
+            "jsessionid": "sess-abc",
+            "xsrf_token": "token-xyz",
+            "auth_type": "session",
+        }
         assert ttl == 1800
 
     def test_auth_without_xsrf_token(self, mocker: MockerFixture) -> None:
@@ -412,7 +416,11 @@ class TestAuthenticateMethod:
             verify_ssl=False,
         )
 
-        assert result == {"jsessionid": "sess-old", "xsrf_token": None}
+        assert result == {
+            "jsessionid": "sess-old",
+            "xsrf_token": None,
+            "auth_type": "session",
+        }
         assert ttl == 1800
 
 
@@ -433,7 +441,7 @@ class TestGetAuthEnvironmentValidation:
             SDWANManagerAuth.get_auth()
 
         assert "SDWAN_URL" in str(exc_info.value)
-        assert "Missing required environment variables" in str(exc_info.value)
+        assert "Missing required environment variable" in str(exc_info.value)
 
     def test_get_auth_missing_username(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Error when SDWAN_USERNAME is missing."""
@@ -458,14 +466,12 @@ class TestGetAuthEnvironmentValidation:
     def test_get_auth_multiple_missing_vars(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Error message includes all missing variables."""
+        """Missing SDWAN_URL fails first (before checking username/password)."""
         with pytest.raises(ValueError) as exc_info:
             SDWANManagerAuth.get_auth()
 
         error_msg = str(exc_info.value)
         assert "SDWAN_URL" in error_msg
-        assert "SDWAN_USERNAME" in error_msg
-        assert "SDWAN_PASSWORD" in error_msg
 
 
 # ===========================================================================
@@ -547,12 +553,11 @@ class TestAuthenticateWithApiToken:
         """Valid JWT with csrf field returns api_token, csrf_token, auth_type."""
         token = _make_jwt({"csrf": "abc123csrf", "sub": "admin"})
 
-        result, ttl = SDWANManagerAuth._authenticate_with_api_token(token)
+        result = SDWANManagerAuth._authenticate_with_api_token(token)
 
         assert result["api_token"] == token
         assert result["csrf_token"] == "abc123csrf"
         assert result["auth_type"] == "token"
-        assert ttl == 3600
 
     def test_jwt_missing_csrf_raises_error(self) -> None:
         """JWT without 'csrf' field raises ValueError."""
@@ -616,29 +621,20 @@ class TestGetAuthApiTokenPriority:
     """Test that SDWAN_API_TOKEN takes priority over username/password."""
 
     def test_api_token_used_when_set(
-        self, mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
+        self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """SDWAN_API_TOKEN takes priority over username/password."""
+        """SDWAN_API_TOKEN takes priority over username/password (no cache)."""
         token = _make_jwt({"csrf": "my-csrf"})
         monkeypatch.setenv("SDWAN_URL", "https://sdwan.example.com")
         monkeypatch.setenv("SDWAN_API_TOKEN", token)
         monkeypatch.setenv("SDWAN_USERNAME", "admin")
         monkeypatch.setenv("SDWAN_PASSWORD", "password123")
 
-        mock_cache = mocker.patch(
-            "nac_test_pyats_common.sdwan.auth.AuthCache.get_or_create"
-        )
-        mock_cache.return_value = {
-            "api_token": token,
-            "csrf_token": "my-csrf",
-            "auth_type": "token",
-        }
-
         result = SDWANManagerAuth.get_auth()
 
         assert result["auth_type"] == "token"
-        call_kwargs = mock_cache.call_args.kwargs
-        assert call_kwargs["controller_type"] == "SDWAN_MANAGER_TOKEN"
+        assert result["api_token"] == token
+        assert result["csrf_token"] == "my-csrf"
 
     def test_session_auth_fallback_when_no_token(
         self, mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/sdwan/test_auth.py
+++ b/tests/unit/sdwan/test_auth.py
@@ -552,7 +552,9 @@ class TestTokenAuth:
         """Patch get_matched_credential_set with token auth CredentialSet."""
         from nac_test.utils.controller import CredentialSet
 
-        mock = mocker.patch("nac_test.utils.controller.get_matched_credential_set")
+        mock = mocker.patch(
+            "nac_test_pyats_common.sdwan.auth.get_matched_credential_set"
+        )
         mock.return_value = CredentialSet(
             env_vars=("SDWAN_URL", "SDWAN_API_TOKEN"),
             label="API Token (20.18+)",

--- a/tests/unit/sdwan/test_auth.py
+++ b/tests/unit/sdwan/test_auth.py
@@ -552,9 +552,7 @@ class TestTokenAuth:
         """Patch get_matched_credential_set with token auth CredentialSet."""
         from nac_test.utils.controller import CredentialSet
 
-        mock = mocker.patch(
-            "nac_test.utils.controller.get_matched_credential_set"
-        )
+        mock = mocker.patch("nac_test.utils.controller.get_matched_credential_set")
         mock.return_value = CredentialSet(
             env_vars=("SDWAN_URL", "SDWAN_API_TOKEN"),
             label="API Token (20.18+)",


### PR DESCRIPTION
## SD-WAN API Token Authentication (20.18+)

### Summary

Adds JWT-based API token authentication support for SD-WAN Manager 20.18+, as an alternative to the existing session-based (username/password) authentication. Auth method selection is driven by nac-test's `CONTROLLER_REGISTRY` credential set matching — when `SDWAN_API_TOKEN` is set alongside `SDWAN_URL`, the token credential set is matched first (order-based priority), and `get_matched_credential_set("SDWAN")` tells `get_auth()` to use token auth.

### Motivation

SD-WAN Manager 20.18 introduced long-lived API tokens as a first-class authentication mechanism. Token auth avoids the overhead of session login/logout, eliminates session expiry issues during long test runs, and simplifies CI/CD pipeline configuration (single env var instead of username + password). 

## Closes

- https://github.com/netascode/nac-test-pyats-common/issues/34

## Related Issue(s)

- Related to nac-test issue - https://github.com/netascode/nac-test/issues/854
- Parent feature request - - Internal NAC-SDWAN issue #1110

### Changes

**`auth.py`** — Core authentication logic (171 lines changed)
- Added `_get_token_auth()` — decodes the JWT payload via base64 (without signature verification, since the server validates on each request), extracts the `csrf` field, and returns `{"auth_method": "token", "api_token": <token>, "csrf_token": <csrf>}`. Validates JWT structure (3 dot-separated parts) and presence of `csrf` field.
- Updated `get_auth()` — imports `get_matched_credential_set("SDWAN")` from nac-test to determine which auth method won during `detect_controller_type()`. Routes to `_get_token_auth()` or `_get_session_auth()` based on `matched.auth_method`.
- Added defense-in-depth env var guards in both `_get_token_auth()` and `_get_session_auth()` — these raise `ValueError` with clear missing-variable messages even though `detect_controller_type()` already validates. Kept because of the package/process boundary between nac-test and nac-test-pyats-common.
- Updated module docstring to document both auth methods, CSRF extraction, and the multi-tier API design.

**`api_test_base.py`** — HTTP client configuration (34 lines changed)
- `get_sdwan_manager_client()` now branches on `auth_data["auth_method"]`:
  - `"token"` → `Authorization: Bearer <token>` + `X-XSRF-TOKEN: <csrf>` from JWT
  - `"session"` → `Cookie: JSESSIONID=...` + optional `X-XSRF-TOKEN` (unchanged behavior)
- Updated docstring to document both auth modes.

**`README.md`** — Updated usage examples to show token auth configuration.

**`CHANGELOG.md`** — Added unreleased entry documenting the feature.

**`dev-docs/PRD_AND_ARCHITECTURE.md`** — Updated architecture documentation with dual-auth flow, CSRF extraction details, and credential set integration.

### Test Coverage

29 unit tests in `test_auth.py` (8 new for token auth, all 144 in repo pass):

| Area | Tests |
|------|-------|
| JWT decoding + CSRF | `test_token_auth_returns_api_token_and_csrf`, `test_token_auth_invalid_jwt_raises`, `test_token_auth_missing_csrf_raises` |
| Token env var validation | `test_token_auth_missing_token_raises`, `test_token_auth_missing_url_raises` |
| Auth method routing | `test_token_auth_no_subprocess_call`, `test_session_auth_when_no_matched_credential_set`, `test_session_auth_includes_auth_method_key` |
| Session auth (existing) | 16 tests covering happy path, failure detection, XSRF validation, env validation, URL normalization |
| Script body | `test_script_body_compiles_after_indent` |

### Design Decisions

- **Auth method driven by `CONTROLLER_REGISTRY`** — `get_auth()` does not independently check env vars to decide token vs session. Instead, nac-test's `detect_controller_type()` matches the first satisfied `CredentialSet` in order (token first, then session), and `get_matched_credential_set("SDWAN")` communicates the result. This keeps auth method selection centralized and deterministic.
- **No caching for token auth** — JWT decoding is a pure in-memory operation (no network call). `_get_token_auth()` bypasses `AuthCache` entirely, unlike session auth which caches the JSESSIONID.
- **Token priority over session** — Defined by credential set order in `CONTROLLER_REGISTRY`: the token set (`SDWAN_URL` + `SDWAN_API_TOKEN`) is listed before the session set (`SDWAN_URL` + `SDWAN_USERNAME` + `SDWAN_PASSWORD`). First fully-satisfied set wins. To force session auth, simply unset `SDWAN_API_TOKEN`.
- **Defense-in-depth env var guards kept** — `_get_token_auth()` and `_get_session_auth()` validate their required env vars even though `detect_controller_type()` already guarantees they're set. This is intentional: nac-test-pyats-common is a separate package consumed across a subprocess boundary, and the near-zero cost of the check is worth the safety.

### How to Use

```bash
# Token auth (20.18+)
export SDWAN_URL="https://sdwan-manager.example.com"
export SDWAN_API_TOKEN="<jwt-token-from-sdwan-manager>"

# Session auth (all versions, unchanged)
export SDWAN_URL="https://sdwan-manager.example.com"
export SDWAN_USERNAME="admin"
export SDWAN_PASSWORD="password"