### PR TITLE
feat(iosxe): get_excluded_features helper for SD-WAN UX 2.0

### DIFF
--- a/src/nac_test_pyats_common/iosxe/test_base.py
+++ b/src/nac_test_pyats_common/iosxe/test_base.py
@@ -3,6 +3,7 @@
 
 """IOS-XE test base class for SSH/D2D testing."""
 
+import logging
 import os
 from typing import Any
 
@@ -10,6 +11,8 @@ from nac_test.pyats_core.common.ssh_base_test import SSHTestBase
 from nac_test.utils.controller import detect_controller_type
 
 from .registry import get_resolver_for_controller
+
+logger = logging.getLogger(__name__)
 
 
 class IOSXETestBase(SSHTestBase):  # type: ignore[misc]
@@ -109,6 +112,62 @@ class IOSXETestBase(SSHTestBase):  # type: ignore[misc]
         else:
             # Default to IOS-XE if no recognized structure
             return "IOSXE"
+
+    @staticmethod
+    def get_excluded_features(
+        router: dict[str, Any], config_group: dict[str, Any]
+    ) -> set[str]:
+        """Return SD-WAN feature names that should be skipped for this router.
+
+        Dual-device configuration groups assign features to specific devices via
+        ``device_tags``. Features tagged for the OTHER device in the pair are
+        excluded for this router.
+
+        Detection order:
+            1. SD-WAN 20.18+ — match by ``router.topology_label``.
+            2. SD-WAN 20.15 and earlier — match by ``router.tags``.
+            3. No ``device_tags`` on the config group, or no router metadata —
+               returns an empty set (no exclusion).
+
+        Args:
+            router: Router dictionary from ``sdwan.sites[].routers[]``.
+            config_group: Configuration group dictionary from
+                ``sdwan.configuration_groups[]``.
+
+        Returns:
+            Set of feature names assigned to the OTHER device in a dual-device
+            pair, which the caller should skip when iterating BGP, OSPF, OMP, or
+            other UX 2.0 feature definitions.
+        """
+        device_tags = config_group.get("device_tags") or []
+        if not device_tags:
+            return set()
+
+        topology_label = router.get("topology_label")
+        if topology_label:
+            return {
+                feature
+                for tag in device_tags
+                if tag.get("name") != topology_label
+                for feature in (tag.get("features") or [])
+            }
+
+        tags = router.get("tags") or []
+        if tags:
+            return {
+                feature
+                for tag in device_tags
+                if tag.get("name") not in tags
+                for feature in (tag.get("features") or [])
+            }
+
+        logger.warning(
+            "Configuration group %r has device_tags but router %r has neither "
+            "topology_label nor tags; no features will be excluded.",
+            config_group.get("name"),
+            router.get("hostname") or router.get("chassis_id"),
+        )
+        return set()
 
     def get_device_credentials(self, device: dict[str, Any]) -> dict[str, str | None]:
         """Get IOS-XE device credentials from environment.

--- a/src/nac_test_pyats_common/iosxe/test_base.py
+++ b/src/nac_test_pyats_common/iosxe/test_base.py
@@ -124,10 +124,24 @@ class IOSXETestBase(SSHTestBase):  # type: ignore[misc]
         excluded for this router.
 
         Detection order:
-            1. SD-WAN 20.18+ — match by ``router.topology_label``.
-            2. SD-WAN 20.15 and earlier — match by ``router.tags``.
-            3. No ``device_tags`` on the config group, or no router metadata —
-               returns an empty set (no exclusion).
+            1. SD-WAN 20.18+ — match by ``router.topology_label`` when it is a
+               non-empty string.
+            2. SD-WAN 20.15 and earlier — match by any non-empty string in
+               ``router.tags``.
+
+        The result is always an empty set on any detection failure (fail-safe:
+        over-test rather than silently skip). The following branches return an
+        empty set:
+
+            * No ``device_tags`` on the config group — silent, nothing to
+              exclude.
+            * Router has neither a usable ``topology_label`` nor any usable
+              ``tags`` — logs a WARNING and returns an empty set.
+            * Router identifier matches no ``device_tags[].name`` (typo,
+              rename, or migration bug) — logs a WARNING and returns an empty
+              set.
+            * A ``device_tags`` entry has ``features`` that is neither ``None``
+              nor a list — logs a WARNING and skips that entry.
 
         Args:
             router: Router dictionary from ``sdwan.sites[].routers[]``.
@@ -136,38 +150,68 @@ class IOSXETestBase(SSHTestBase):  # type: ignore[misc]
 
         Returns:
             Set of feature names assigned to the OTHER device in a dual-device
-            pair, which the caller should skip when iterating BGP, OSPF, OMP, or
-            other UX 2.0 feature definitions.
+            pair, which the caller should skip when iterating BGP, OSPF, OMP,
+            or other UX 2.0 feature definitions.
         """
         device_tags = config_group.get("device_tags") or []
         if not device_tags:
             return set()
 
+        group_name = config_group.get("name")
+        router_identity = router.get("hostname") or router.get("chassis_id")
+
         topology_label = router.get("topology_label")
-        if topology_label:
-            return {
-                feature
-                for tag in device_tags
-                if tag.get("name") != topology_label
-                for feature in (tag.get("features") or [])
-            }
+        if isinstance(topology_label, str) and topology_label:
+            router_tag_names: list[str] = [topology_label]
+        else:
+            raw_tags = router.get("tags") or []
+            router_tag_names = (
+                [t for t in raw_tags if isinstance(t, str) and t]
+                if isinstance(raw_tags, list)
+                else []
+            )
 
-        tags = router.get("tags") or []
-        if tags:
-            return {
-                feature
-                for tag in device_tags
-                if tag.get("name") not in tags
-                for feature in (tag.get("features") or [])
-            }
+        if not router_tag_names:
+            logger.warning(
+                "Configuration group %r has device_tags but router %r has "
+                "neither topology_label nor tags; no features will be excluded.",
+                group_name,
+                router_identity,
+            )
+            return set()
 
-        logger.warning(
-            "Configuration group %r has device_tags but router %r has neither "
-            "topology_label nor tags; no features will be excluded.",
-            config_group.get("name"),
-            router.get("hostname") or router.get("chassis_id"),
-        )
-        return set()
+        device_tag_names = {
+            tag.get("name") for tag in device_tags if isinstance(tag.get("name"), str)
+        }
+        if device_tag_names.isdisjoint(router_tag_names):
+            logger.warning(
+                "Router %r identifier(s) %r match no device_tags in "
+                "configuration group %r; no features will be excluded.",
+                router_identity,
+                router_tag_names,
+                group_name,
+            )
+            return set()
+
+        excluded: set[str] = set()
+        for tag in device_tags:
+            name = tag.get("name")
+            if not isinstance(name, str) or name in router_tag_names:
+                continue
+            features = tag.get("features")
+            if features is None:
+                continue
+            if not isinstance(features, list):
+                logger.warning(
+                    "Configuration group %r device_tag %r has features of type "
+                    "%s (expected list); ignoring.",
+                    group_name,
+                    name,
+                    type(features).__name__,
+                )
+                continue
+            excluded.update(f for f in features if isinstance(f, str))
+        return excluded
 
     def get_device_credentials(self, device: dict[str, Any]) -> dict[str, str | None]:
         """Get IOS-XE device credentials from environment.

--- a/tests/unit/iosxe/test_base.py
+++ b/tests/unit/iosxe/test_base.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2025 Daniel Schmidt
+
+"""Unit tests for IOSXETestBase helper methods."""
+
+from nac_test_pyats_common.iosxe.test_base import IOSXETestBase
+
+
+def test_excluded_features_empty_when_no_device_tags() -> None:
+    """Config group without device_tags returns an empty exclusion set."""
+    router = {"topology_label": "primary"}
+    config_group = {"name": "cg1"}
+
+    assert IOSXETestBase.get_excluded_features(router, config_group) == set()
+
+
+def test_excluded_features_uses_topology_label_when_present() -> None:
+    """SD-WAN 20.18+: topology_label selects which device_tag is 'this' router."""
+    router = {"topology_label": "primary", "tags": ["legacy-tag"]}
+    config_group = {
+        "name": "cg1",
+        "device_tags": [
+            {"name": "primary", "features": ["bgp_a", "ospf_a"]},
+            {"name": "secondary", "features": ["bgp_b", "ospf_b"]},
+        ],
+    }
+
+    assert IOSXETestBase.get_excluded_features(router, config_group) == {
+        "bgp_b",
+        "ospf_b",
+    }
+
+
+def test_excluded_features_falls_back_to_tags_when_no_topology_label() -> None:
+    """SD-WAN 20.15 and earlier: tags select which device_tag is 'this' router."""
+    router = {"tags": ["secondary"]}
+    config_group = {
+        "name": "cg1",
+        "device_tags": [
+            {"name": "primary", "features": ["bgp_a"]},
+            {"name": "secondary", "features": ["bgp_b"]},
+        ],
+    }
+
+    assert IOSXETestBase.get_excluded_features(router, config_group) == {"bgp_a"}
+
+
+def test_excluded_features_returns_empty_when_router_has_no_metadata() -> None:
+    """Router missing both topology_label and tags falls through to empty set."""
+    router = {"chassis_id": "C1234"}
+    config_group = {
+        "name": "cg1",
+        "device_tags": [
+            {"name": "primary", "features": ["bgp_a"]},
+        ],
+    }
+
+    assert IOSXETestBase.get_excluded_features(router, config_group) == set()
+
+
+def test_excluded_features_handles_missing_features_list() -> None:
+    """Device tags with absent or null 'features' do not break the set comprehension."""
+    router = {"topology_label": "primary"}
+    config_group = {
+        "name": "cg1",
+        "device_tags": [
+            {"name": "primary"},  # no features key
+            {"name": "secondary", "features": None},
+        ],
+    }
+
+    assert IOSXETestBase.get_excluded_features(router, config_group) == set()

--- a/tests/unit/iosxe/test_base.py
+++ b/tests/unit/iosxe/test_base.py
@@ -3,6 +3,10 @@
 
 """Unit tests for IOSXETestBase helper methods."""
 
+import logging
+
+import pytest
+
 from nac_test_pyats_common.iosxe.test_base import IOSXETestBase
 
 
@@ -45,8 +49,15 @@ def test_excluded_features_falls_back_to_tags_when_no_topology_label() -> None:
     assert IOSXETestBase.get_excluded_features(router, config_group) == {"bgp_a"}
 
 
-def test_excluded_features_returns_empty_when_router_has_no_metadata() -> None:
-    """Router missing both topology_label and tags falls through to empty set."""
+def test_excluded_features_returns_empty_when_router_has_no_metadata(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Router missing both topology_label and tags returns empty set + WARNING.
+
+    The warning is the operator-facing signal that the data model is
+    mis-tagged. We assert level and identifying fields, not exact wording,
+    so message rewording doesn't break the test.
+    """
     router = {"chassis_id": "C1234"}
     config_group = {
         "name": "cg1",
@@ -55,7 +66,15 @@ def test_excluded_features_returns_empty_when_router_has_no_metadata() -> None:
         ],
     }
 
-    assert IOSXETestBase.get_excluded_features(router, config_group) == set()
+    with caplog.at_level(logging.WARNING):
+        result = IOSXETestBase.get_excluded_features(router, config_group)
+
+    assert result == set()
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    rendered = warnings[0].getMessage()
+    assert "cg1" in rendered
+    assert "C1234" in rendered
 
 
 def test_excluded_features_handles_missing_features_list() -> None:
@@ -70,3 +89,96 @@ def test_excluded_features_handles_missing_features_list() -> None:
     }
 
     assert IOSXETestBase.get_excluded_features(router, config_group) == set()
+
+
+def test_excluded_features_empty_when_topology_label_matches_no_device_tag(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Fail-safe: an unrecognized topology_label excludes nothing (not everything).
+
+    A typo in ``topology_label`` (or a config-group rename) would previously
+    have flagged every device_tag as 'the other device' and silently skipped
+    all features. Fail-safe direction is now to log and return an empty set.
+    """
+    router = {"topology_label": "tertiary"}
+    config_group = {
+        "name": "cg1",
+        "device_tags": [
+            {"name": "primary", "features": ["bgp_a"]},
+            {"name": "secondary", "features": ["bgp_b"]},
+        ],
+    }
+
+    with caplog.at_level(logging.WARNING):
+        result = IOSXETestBase.get_excluded_features(router, config_group)
+
+    assert result == set()
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert "tertiary" in warnings[0].getMessage()
+
+
+def test_excluded_features_empty_when_tags_match_no_device_tag(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Fail-safe applies to the UX 1.0 tags path as well."""
+    router = {"tags": ["unknown"]}
+    config_group = {
+        "name": "cg1",
+        "device_tags": [
+            {"name": "primary", "features": ["bgp_a"]},
+            {"name": "secondary", "features": ["bgp_b"]},
+        ],
+    }
+
+    with caplog.at_level(logging.WARNING):
+        result = IOSXETestBase.get_excluded_features(router, config_group)
+
+    assert result == set()
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert "unknown" in warnings[0].getMessage()
+
+
+def test_excluded_features_empty_string_topology_label_falls_back_to_tags() -> None:
+    """Empty-string topology_label is treated as absent; UX 1.0 tags path applies.
+
+    Prevents a partially-migrated UX 2.0 router with an empty ``topology_label``
+    from silently degrading to legacy semantics without an intentional signal.
+    """
+    router = {"topology_label": "", "tags": ["secondary"]}
+    config_group = {
+        "name": "cg1",
+        "device_tags": [
+            {"name": "primary", "features": ["bgp_a"]},
+            {"name": "secondary", "features": ["bgp_b"]},
+        ],
+    }
+
+    assert IOSXETestBase.get_excluded_features(router, config_group) == {"bgp_a"}
+
+
+def test_excluded_features_ignores_non_list_features_with_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A ``features`` value that is a scalar (YAML mistake) is skipped, not iterated.
+
+    Without this guard, ``for feature in "bgp_a"`` would yield individual
+    characters into the exclusion set.
+    """
+    router = {"topology_label": "primary"}
+    config_group = {
+        "name": "cg1",
+        "device_tags": [
+            {"name": "primary", "features": ["bgp_a"]},
+            {"name": "secondary", "features": "bgp_b"},  # scalar, not list
+        ],
+    }
+
+    with caplog.at_level(logging.WARNING):
+        result = IOSXETestBase.get_excluded_features(router, config_group)
+
+    assert result == set()
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert "secondary" in warnings[0].getMessage()


### PR DESCRIPTION
## Summary

Adds `IOSXETestBase.get_excluded_features(router, config_group) -> set[str]` so SD-WAN verification tests can support UX 2.0's excluded-feature behavior with a single call instead of inlining the dual-device `device_tags` filter in each test case.

**Detection:**
- 20.18+ matches by non-empty `router.topology_label`
- 20.15 and earlier matches by any non-empty string in `router.tags`

**Fail-safe direction on any detection failure** (empty `device_tags`, no usable router identifier, identifier matches no `device_tags[].name`, or malformed `features`): return an empty `set[str]` — over-test rather than silently skip — and log a WARNING for operator visibility.

Returns `set[str]` for O(1) membership at the call site.

## Test plan

- [x] 9 unit tests covering each detection branch, each fail-safe branch, and edge cases (empty-string `topology_label`, non-list `features`, no matching `device_tags[].name`)
- [x] Warning branches verified via `caplog` (level + identifying fields, not exact phrase)
- [x] `ruff check` clean
- [x] `mypy` clean

Closes #38

Co-Authored-By: Claude <noreply@anthropic.com>