### PR TITLE
feat(sdwan): add get_devices_from_data_model() to SDWANManagerTestBase

### DIFF
--- a/src/nac_test_pyats_common/sdwan/api_test_base.py
+++ b/src/nac_test_pyats_common/sdwan/api_test_base.py
@@ -176,9 +176,9 @@ class SDWANManagerTestBase(NACTestBase):  # type: ignore[misc]
         Example:
             >>> devices = self.get_devices_from_data_model()
             >>> for device in devices:
-            ...     response = await client.get(
-            ...         f"/dataservice/device/control/connections?deviceId={device['system_ip']}"
-            ...     )
+            ...     url = f"/dataservice/device/bfd/sessions"
+            ...     url += f"?deviceId={device['system_ip']}"
+            ...     response = await client.get(url)
         """
         devices: list[dict[str, Any]] = []
         sdwan = self.data_model.get("sdwan", {})
@@ -197,11 +197,13 @@ class SDWANManagerTestBase(NACTestBase):  # type: ignore[misc]
                     or vars_.get("system_hostname")
                     or str(system_ip)
                 )
-                devices.append({
-                    "system_ip": system_ip,
-                    "site_id": site_id,
-                    "hostname": hostname,
-                })
+                devices.append(
+                    {
+                        "system_ip": system_ip,
+                        "site_id": site_id,
+                        "hostname": hostname,
+                    }
+                )
 
         return devices
 

--- a/src/nac_test_pyats_common/sdwan/api_test_base.py
+++ b/src/nac_test_pyats_common/sdwan/api_test_base.py
@@ -148,6 +148,63 @@ class SDWANManagerTestBase(NACTestBase):  # type: ignore[misc]
         # Use the generic tracking wrapper from base class
         return self.wrap_client_for_tracking(base_client, device_name="SDWAN Manager")  # type: ignore[no-any-return]
 
+    def get_devices_from_data_model(self) -> list[dict[str, Any]]:
+        """Extract SD-WAN device identifiers from the NAC data model for API queries.
+
+        Navigates the standard NaC SD-WAN schema structure to extract the system_ip,
+        site_id, and hostname for each router across all sites. These identifiers are
+        used as query parameters (deviceId) when querying per-device operational state
+        from the SD-WAN Manager dataservice API.
+
+        Schema structure supported:
+            sdwan:
+              sites:
+                - id: 100
+                  routers:
+                    - device_variables:
+                        system_ip: "10.0.0.1"
+                        site_id: 100
+                        host_name: "router1"         # UX 2.0
+                        system_hostname: "router1"   # UX 1.0
+
+        Returns:
+            List of dictionaries, each containing:
+                - system_ip (str): Device system IP used as deviceId in API queries
+                - site_id (str | int | None): Site identifier
+                - hostname (str): Human-readable device name for logging/reporting
+
+        Example:
+            >>> devices = self.get_devices_from_data_model()
+            >>> for device in devices:
+            ...     response = await client.get(
+            ...         f"/dataservice/device/control/connections?deviceId={device['system_ip']}"
+            ...     )
+        """
+        devices: list[dict[str, Any]] = []
+        sdwan = self.data_model.get("sdwan", {})
+
+        for site in sdwan.get("sites", []):
+            site_id_fallback = site.get("id")
+            for router in site.get("routers", []):
+                vars_ = router.get("device_variables", {})
+                system_ip = vars_.get("system_ip")
+                if not system_ip:
+                    continue
+
+                site_id = vars_.get("site_id") or site_id_fallback
+                hostname = (
+                    vars_.get("host_name")
+                    or vars_.get("system_hostname")
+                    or str(system_ip)
+                )
+                devices.append({
+                    "system_ip": system_ip,
+                    "site_id": site_id,
+                    "hostname": hostname,
+                })
+
+        return devices
+
     def run_async_verification_test(self, steps: Any) -> None:
         """Execute asynchronous verification tests with PyATS step tracking.
 

--- a/tests/unit/sdwan/conftest.py
+++ b/tests/unit/sdwan/conftest.py
@@ -3,25 +3,24 @@
 
 """Shared fixtures for SD-WAN unit tests."""
 
+from collections.abc import Callable
 from typing import Any
 from unittest.mock import patch
 
 import pytest
 
+from nac_test_pyats_common.sdwan.api_test_base import SDWANManagerTestBase
+
 
 @pytest.fixture
-def make_base_instance():
+def make_base_instance() -> Callable[[dict[str, Any]], SDWANManagerTestBase]:
     """Create a minimal SDWANManagerTestBase instance with a mocked data_model."""
 
-    def _factory(data_model: dict[str, Any]):
+    def _factory(data_model: dict[str, Any]) -> SDWANManagerTestBase:
         with patch(
             "nac_test_pyats_common.sdwan.api_test_base.SDWANManagerTestBase.__init__",
             return_value=None,
         ):
-            from nac_test_pyats_common.sdwan.api_test_base import (
-                SDWANManagerTestBase,
-            )
-
             instance = SDWANManagerTestBase.__new__(SDWANManagerTestBase)
             instance.data_model = data_model
             return instance

--- a/tests/unit/sdwan/conftest.py
+++ b/tests/unit/sdwan/conftest.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2025 Daniel Schmidt
+
+"""Shared fixtures for SD-WAN unit tests."""
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def make_base_instance():
+    """Create a minimal SDWANManagerTestBase instance with a mocked data_model."""
+
+    def _factory(data_model: dict[str, Any]):
+        with patch(
+            "nac_test_pyats_common.sdwan.api_test_base.SDWANManagerTestBase.__init__",
+            return_value=None,
+        ):
+            from nac_test_pyats_common.sdwan.api_test_base import (
+                SDWANManagerTestBase,
+            )
+
+            instance = SDWANManagerTestBase.__new__(SDWANManagerTestBase)
+            instance.data_model = data_model
+            return instance
+
+    return _factory

--- a/tests/unit/sdwan/test_api_test_base.py
+++ b/tests/unit/sdwan/test_api_test_base.py
@@ -1,0 +1,271 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2025 Daniel Schmidt
+
+"""Unit tests for SDWANManagerTestBase.get_devices_from_data_model().
+
+Tests the data model navigation logic that extracts device identifiers
+(system_ip, site_id, hostname) from the NaC SD-WAN schema for use as
+API query parameters.
+"""
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def make_base_instance():
+    """Create a minimal SDWANManagerTestBase instance with a mocked data_model."""
+
+    def _factory(data_model: dict[str, Any]):
+        with patch(
+            "nac_test_pyats_common.sdwan.api_test_base.SDWANManagerTestBase.__init__",
+            return_value=None,
+        ):
+            from nac_test_pyats_common.sdwan.api_test_base import (
+                SDWANManagerTestBase,
+            )
+
+            instance = SDWANManagerTestBase.__new__(SDWANManagerTestBase)
+            instance.data_model = data_model
+            return instance
+
+    return _factory
+
+
+class TestGetDevicesFromDataModel:
+    """Tests for get_devices_from_data_model method."""
+
+    def test_extracts_devices_from_single_site(self, make_base_instance):
+        """Extracts devices from a single site with routers."""
+        data_model = {
+            "sdwan": {
+                "sites": [
+                    {
+                        "id": 100,
+                        "routers": [
+                            {
+                                "device_variables": {
+                                    "system_ip": "10.0.0.1",
+                                    "site_id": 100,
+                                    "host_name": "dc-edge-01",
+                                },
+                            },
+                        ],
+                    },
+                ],
+            },
+        }
+        instance = make_base_instance(data_model)
+        devices = instance.get_devices_from_data_model()
+
+        assert len(devices) == 1
+        assert devices[0]["system_ip"] == "10.0.0.1"
+        assert devices[0]["site_id"] == 100
+        assert devices[0]["hostname"] == "dc-edge-01"
+
+    def test_extracts_devices_from_multiple_sites(self, make_base_instance):
+        """Extracts devices across multiple sites."""
+        data_model = {
+            "sdwan": {
+                "sites": [
+                    {
+                        "id": 100,
+                        "routers": [
+                            {
+                                "device_variables": {
+                                    "system_ip": "10.0.0.1",
+                                    "site_id": 100,
+                                    "host_name": "dc-edge-01",
+                                },
+                            },
+                        ],
+                    },
+                    {
+                        "id": 200,
+                        "routers": [
+                            {
+                                "device_variables": {
+                                    "system_ip": "10.0.0.3",
+                                    "site_id": 200,
+                                    "host_name": "br-edge-01",
+                                },
+                            },
+                            {
+                                "device_variables": {
+                                    "system_ip": "10.0.0.4",
+                                    "site_id": 200,
+                                    "host_name": "br-edge-02",
+                                },
+                            },
+                        ],
+                    },
+                ],
+            },
+        }
+        instance = make_base_instance(data_model)
+        devices = instance.get_devices_from_data_model()
+
+        assert len(devices) == 3
+        assert devices[0]["system_ip"] == "10.0.0.1"
+        assert devices[1]["system_ip"] == "10.0.0.3"
+        assert devices[2]["system_ip"] == "10.0.0.4"
+
+    def test_uses_system_hostname_for_ux1(self, make_base_instance):
+        """Falls back to system_hostname (UX 1.0) when host_name not present."""
+        data_model = {
+            "sdwan": {
+                "sites": [
+                    {
+                        "id": 300,
+                        "routers": [
+                            {
+                                "device_variables": {
+                                    "system_ip": "10.0.0.5",
+                                    "site_id": 300,
+                                    "system_hostname": "SD-BR02-C8KV-R1",
+                                },
+                            },
+                        ],
+                    },
+                ],
+            },
+        }
+        instance = make_base_instance(data_model)
+        devices = instance.get_devices_from_data_model()
+
+        assert devices[0]["hostname"] == "SD-BR02-C8KV-R1"
+
+    def test_falls_back_to_system_ip_for_hostname(self, make_base_instance):
+        """Uses system_ip when no host_name or system_hostname exists."""
+        data_model = {
+            "sdwan": {
+                "sites": [
+                    {
+                        "id": 100,
+                        "routers": [
+                            {
+                                "device_variables": {
+                                    "system_ip": "10.0.0.1",
+                                    "site_id": 100,
+                                },
+                            },
+                        ],
+                    },
+                ],
+            },
+        }
+        instance = make_base_instance(data_model)
+        devices = instance.get_devices_from_data_model()
+
+        assert devices[0]["hostname"] == "10.0.0.1"
+
+    def test_uses_site_id_from_site_level(self, make_base_instance):
+        """Falls back to site-level id when device_variables has no site_id."""
+        data_model = {
+            "sdwan": {
+                "sites": [
+                    {
+                        "id": 100,
+                        "routers": [
+                            {
+                                "device_variables": {
+                                    "system_ip": "10.0.0.1",
+                                    "host_name": "router1",
+                                },
+                            },
+                        ],
+                    },
+                ],
+            },
+        }
+        instance = make_base_instance(data_model)
+        devices = instance.get_devices_from_data_model()
+
+        assert devices[0]["site_id"] == 100
+
+    def test_skips_routers_without_system_ip(self, make_base_instance):
+        """Routers missing system_ip are excluded from results."""
+        data_model = {
+            "sdwan": {
+                "sites": [
+                    {
+                        "id": 100,
+                        "routers": [
+                            {
+                                "device_variables": {
+                                    "system_ip": "10.0.0.1",
+                                    "host_name": "router1",
+                                },
+                            },
+                            {
+                                "device_variables": {
+                                    "host_name": "router-no-ip",
+                                },
+                            },
+                        ],
+                    },
+                ],
+            },
+        }
+        instance = make_base_instance(data_model)
+        devices = instance.get_devices_from_data_model()
+
+        assert len(devices) == 1
+        assert devices[0]["hostname"] == "router1"
+
+    def test_returns_empty_list_for_no_sites(self, make_base_instance):
+        """Returns empty list when no sites are defined."""
+        data_model = {"sdwan": {"sites": []}}
+        instance = make_base_instance(data_model)
+        devices = instance.get_devices_from_data_model()
+
+        assert devices == []
+
+    def test_returns_empty_list_for_empty_data_model(self, make_base_instance):
+        """Returns empty list when data model has no sdwan key."""
+        data_model = {}
+        instance = make_base_instance(data_model)
+        devices = instance.get_devices_from_data_model()
+
+        assert devices == []
+
+    def test_handles_site_with_no_routers(self, make_base_instance):
+        """Gracefully handles sites that have no routers key."""
+        data_model = {
+            "sdwan": {
+                "sites": [
+                    {"id": 100},
+                ],
+            },
+        }
+        instance = make_base_instance(data_model)
+        devices = instance.get_devices_from_data_model()
+
+        assert devices == []
+
+    def test_host_name_takes_priority_over_system_hostname(self, make_base_instance):
+        """host_name (UX 2.0) is preferred over system_hostname (UX 1.0)."""
+        data_model = {
+            "sdwan": {
+                "sites": [
+                    {
+                        "id": 100,
+                        "routers": [
+                            {
+                                "device_variables": {
+                                    "system_ip": "10.0.0.1",
+                                    "host_name": "ux2-name",
+                                    "system_hostname": "ux1-name",
+                                },
+                            },
+                        ],
+                    },
+                ],
+            },
+        }
+        instance = make_base_instance(data_model)
+        devices = instance.get_devices_from_data_model()
+
+        assert devices[0]["hostname"] == "ux2-name"

--- a/tests/unit/sdwan/test_api_test_base.py
+++ b/tests/unit/sdwan/test_api_test_base.py
@@ -300,7 +300,7 @@ class TestGetDevicesFromDataModel:
         self, make_base_instance: _MakeInstance
     ) -> None:
         """Returns empty list when no sites are defined."""
-        data_model = {"sdwan": {"sites": []}}
+        data_model: dict[str, Any] = {"sdwan": {"sites": []}}
         instance = make_base_instance(data_model)
         devices = instance.get_devices_from_data_model()
 
@@ -310,7 +310,7 @@ class TestGetDevicesFromDataModel:
         self, make_base_instance: _MakeInstance
     ) -> None:
         """Returns empty list when data model has no sdwan key."""
-        data_model = {}
+        data_model: dict[str, Any] = {}
         instance = make_base_instance(data_model)
         devices = instance.get_devices_from_data_model()
 

--- a/tests/unit/sdwan/test_api_test_base.py
+++ b/tests/unit/sdwan/test_api_test_base.py
@@ -8,31 +8,6 @@ Tests the data model navigation logic that extracts device identifiers
 API query parameters.
 """
 
-from typing import Any
-from unittest.mock import patch
-
-import pytest
-
-
-@pytest.fixture
-def make_base_instance():
-    """Create a minimal SDWANManagerTestBase instance with a mocked data_model."""
-
-    def _factory(data_model: dict[str, Any]):
-        with patch(
-            "nac_test_pyats_common.sdwan.api_test_base.SDWANManagerTestBase.__init__",
-            return_value=None,
-        ):
-            from nac_test_pyats_common.sdwan.api_test_base import (
-                SDWANManagerTestBase,
-            )
-
-            instance = SDWANManagerTestBase.__new__(SDWANManagerTestBase)
-            instance.data_model = data_model
-            return instance
-
-    return _factory
-
 
 class TestGetDevicesFromDataModel:
     """Tests for get_devices_from_data_model method."""

--- a/tests/unit/sdwan/test_api_test_base.py
+++ b/tests/unit/sdwan/test_api_test_base.py
@@ -8,12 +8,17 @@ Tests cover:
 - Data model navigation in get_devices_from_data_model()
 """
 
+from collections.abc import Callable
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 from pytest_mock import MockerFixture
 
 from nac_test_pyats_common.sdwan.api_test_base import SDWANManagerTestBase
+
+# Type alias for the make_base_instance fixture
+_MakeInstance = Callable[[dict[str, Any]], SDWANManagerTestBase]
 
 
 @pytest.fixture
@@ -101,7 +106,9 @@ class TestGetSDWANManagerClientHeaders:
 class TestGetDevicesFromDataModel:
     """Tests for get_devices_from_data_model method."""
 
-    def test_extracts_devices_from_single_site(self, make_base_instance):
+    def test_extracts_devices_from_single_site(
+        self, make_base_instance: _MakeInstance
+    ) -> None:
         """Extracts devices from a single site with routers."""
         data_model = {
             "sdwan": {
@@ -129,7 +136,9 @@ class TestGetDevicesFromDataModel:
         assert devices[0]["site_id"] == 100
         assert devices[0]["hostname"] == "dc-edge-01"
 
-    def test_extracts_devices_from_multiple_sites(self, make_base_instance):
+    def test_extracts_devices_from_multiple_sites(
+        self, make_base_instance: _MakeInstance
+    ) -> None:
         """Extracts devices across multiple sites."""
         data_model = {
             "sdwan": {
@@ -176,7 +185,9 @@ class TestGetDevicesFromDataModel:
         assert devices[1]["system_ip"] == "10.0.0.3"
         assert devices[2]["system_ip"] == "10.0.0.4"
 
-    def test_uses_system_hostname_for_ux1(self, make_base_instance):
+    def test_uses_system_hostname_for_ux1(
+        self, make_base_instance: _MakeInstance
+    ) -> None:
         """Falls back to system_hostname (UX 1.0) when host_name not present."""
         data_model = {
             "sdwan": {
@@ -201,7 +212,9 @@ class TestGetDevicesFromDataModel:
 
         assert devices[0]["hostname"] == "SD-BR02-C8KV-R1"
 
-    def test_falls_back_to_system_ip_for_hostname(self, make_base_instance):
+    def test_falls_back_to_system_ip_for_hostname(
+        self, make_base_instance: _MakeInstance
+    ) -> None:
         """Uses system_ip when no host_name or system_hostname exists."""
         data_model = {
             "sdwan": {
@@ -225,7 +238,9 @@ class TestGetDevicesFromDataModel:
 
         assert devices[0]["hostname"] == "10.0.0.1"
 
-    def test_uses_site_id_from_site_level(self, make_base_instance):
+    def test_uses_site_id_from_site_level(
+        self, make_base_instance: _MakeInstance
+    ) -> None:
         """Falls back to site-level id when device_variables has no site_id."""
         data_model = {
             "sdwan": {
@@ -249,7 +264,9 @@ class TestGetDevicesFromDataModel:
 
         assert devices[0]["site_id"] == 100
 
-    def test_skips_routers_without_system_ip(self, make_base_instance):
+    def test_skips_routers_without_system_ip(
+        self, make_base_instance: _MakeInstance
+    ) -> None:
         """Routers missing system_ip are excluded from results."""
         data_model = {
             "sdwan": {
@@ -279,7 +296,9 @@ class TestGetDevicesFromDataModel:
         assert len(devices) == 1
         assert devices[0]["hostname"] == "router1"
 
-    def test_returns_empty_list_for_no_sites(self, make_base_instance):
+    def test_returns_empty_list_for_no_sites(
+        self, make_base_instance: _MakeInstance
+    ) -> None:
         """Returns empty list when no sites are defined."""
         data_model = {"sdwan": {"sites": []}}
         instance = make_base_instance(data_model)
@@ -287,7 +306,9 @@ class TestGetDevicesFromDataModel:
 
         assert devices == []
 
-    def test_returns_empty_list_for_empty_data_model(self, make_base_instance):
+    def test_returns_empty_list_for_empty_data_model(
+        self, make_base_instance: _MakeInstance
+    ) -> None:
         """Returns empty list when data model has no sdwan key."""
         data_model = {}
         instance = make_base_instance(data_model)
@@ -295,7 +316,9 @@ class TestGetDevicesFromDataModel:
 
         assert devices == []
 
-    def test_handles_site_with_no_routers(self, make_base_instance):
+    def test_handles_site_with_no_routers(
+        self, make_base_instance: _MakeInstance
+    ) -> None:
         """Gracefully handles sites that have no routers key."""
         data_model = {
             "sdwan": {
@@ -309,7 +332,9 @@ class TestGetDevicesFromDataModel:
 
         assert devices == []
 
-    def test_host_name_takes_priority_over_system_hostname(self, make_base_instance):
+    def test_host_name_takes_priority_over_system_hostname(
+        self, make_base_instance: _MakeInstance
+    ) -> None:
         """host_name (UX 2.0) is preferred over system_hostname (UX 1.0)."""
         data_model = {
             "sdwan": {


### PR DESCRIPTION
## Summary

- Adds `get_devices_from_data_model()` method to `SDWANManagerTestBase` that navigates `sdwan.sites[].routers[].device_variables` to extract device system_ip, site_id, and hostname
- These identifiers are used as `deviceId` query parameters when querying per-device operational state from the SD-WAN Manager dataservice API
- Consolidates a pattern needed by all per-device operational tests (control connections, BFD sessions, BGP neighbors) that would otherwise duplicate the same data model navigation logic

## Context

When writing SD-WAN operational tests that verify per-device state (BFD sessions up, control connections up, BGP established), every test needs to answer "which devices should I check?" by walking the NAC data model. Without this method, each test duplicates ~12 lines of schema navigation. This is analogous to ACI tests using `jmespath.search("apic.tenants[]", self.data_model)` inline, but since SDWAN operational tests all start from the same schema path, a shared method is more appropriate.

## Test plan

- [ ] Verify method returns correct device list from a merged data model with both UX1 and UX2 sites
- [ ] Verify graceful handling of empty data model (returns `[]`)
- [ ] Verify routers without `system_ip` in device_variables are skipped
- [ ] Integration: use in SDWAN-as-Code-Demo operational tests against live lab

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: claude-opus-4-6
- **AI Contribution**: ~90%
- **AI Reason**: utility method implementation + docstring
- **Human Oversight**: Code reviewed and approved by ChristopherJHart