### PR TITLE
feat(sdwan): add NAC_TEST_DEVICE_TAG filtering to device discovery

### DIFF
--- a/src/nac_test_pyats_common/sdwan/api_test_base.py
+++ b/src/nac_test_pyats_common/sdwan/api_test_base.py
@@ -211,11 +211,13 @@ class SDWANManagerTestBase(NACTestBase):  # type: ignore[misc]
                     or vars_.get("system_hostname")
                     or str(system_ip)
                 )
-                devices.append({
-                    "system_ip": system_ip,
-                    "site_id": site_id,
-                    "hostname": hostname,
-                })
+                devices.append(
+                    {
+                        "system_ip": system_ip,
+                        "site_id": site_id,
+                        "hostname": hostname,
+                    }
+                )
 
         return devices
 

--- a/src/nac_test_pyats_common/sdwan/api_test_base.py
+++ b/src/nac_test_pyats_common/sdwan/api_test_base.py
@@ -155,6 +155,63 @@ class SDWANManagerTestBase(NACTestBase):  # type: ignore[misc]
         # Use the generic tracking wrapper from base class
         return self.wrap_client_for_tracking(base_client, device_name="SDWAN Manager")  # type: ignore[no-any-return]
 
+    def get_devices_from_data_model(self) -> list[dict[str, Any]]:
+        """Extract SD-WAN device identifiers from the NAC data model for API queries.
+
+        Navigates the standard NaC SD-WAN schema structure to extract the system_ip,
+        site_id, and hostname for each router across all sites. These identifiers are
+        used as query parameters (deviceId) when querying per-device operational state
+        from the SD-WAN Manager dataservice API.
+
+        Schema structure supported:
+            sdwan:
+              sites:
+                - id: 100
+                  routers:
+                    - device_variables:
+                        system_ip: "10.0.0.1"
+                        site_id: 100
+                        host_name: "router1"         # UX 2.0
+                        system_hostname: "router1"   # UX 1.0
+
+        Returns:
+            List of dictionaries, each containing:
+                - system_ip (str): Device system IP used as deviceId in API queries
+                - site_id (str | int | None): Site identifier
+                - hostname (str): Human-readable device name for logging/reporting
+
+        Example:
+            >>> devices = self.get_devices_from_data_model()
+            >>> for device in devices:
+            ...     response = await client.get(
+            ...         f"/dataservice/device/control/connections?deviceId={device['system_ip']}"
+            ...     )
+        """
+        devices: list[dict[str, Any]] = []
+        sdwan = self.data_model.get("sdwan", {})
+
+        for site in sdwan.get("sites", []):
+            site_id_fallback = site.get("id")
+            for router in site.get("routers", []):
+                vars_ = router.get("device_variables", {})
+                system_ip = vars_.get("system_ip")
+                if not system_ip:
+                    continue
+
+                site_id = vars_.get("site_id") or site_id_fallback
+                hostname = (
+                    vars_.get("host_name")
+                    or vars_.get("system_hostname")
+                    or str(system_ip)
+                )
+                devices.append({
+                    "system_ip": system_ip,
+                    "site_id": site_id,
+                    "hostname": hostname,
+                })
+
+        return devices
+
     def run_async_verification_test(self, steps: Any) -> None:
         """Execute asynchronous verification tests with PyATS step tracking.
 

--- a/src/nac_test_pyats_common/sdwan/api_test_base.py
+++ b/src/nac_test_pyats_common/sdwan/api_test_base.py
@@ -14,6 +14,7 @@ API call tracking for enhanced HTML reporting.
 """
 
 import asyncio
+import os
 from typing import Any
 
 import httpx
@@ -189,10 +190,16 @@ class SDWANManagerTestBase(NACTestBase):  # type: ignore[misc]
         """
         devices: list[dict[str, Any]] = []
         sdwan = self.data_model.get("sdwan", {})
+        device_tag = os.environ.get("NAC_TEST_DEVICE_TAG")
 
         for site in sdwan.get("sites", []):
             site_id_fallback = site.get("id")
             for router in site.get("routers", []):
+                if device_tag:
+                    tags = router.get("tags") or []
+                    if device_tag not in tags:
+                        continue
+
                 vars_ = router.get("device_variables", {})
                 system_ip = vars_.get("system_ip")
                 if not system_ip:

--- a/src/nac_test_pyats_common/sdwan/device_resolver.py
+++ b/src/nac_test_pyats_common/sdwan/device_resolver.py
@@ -19,6 +19,7 @@ Device Fields Returned:
 """
 
 import logging
+import os
 from typing import Any
 
 from nac_test_pyats_common.common import BaseDeviceResolver
@@ -83,17 +84,23 @@ class SDWANDeviceResolver(BaseDeviceResolver):
         """Navigate SD-WAN schema: sdwan.sites[].routers[].
 
         Traverses the SD-WAN data model structure to find all router
-        devices across all sites.
+        devices across all sites. When NAC_TEST_DEVICE_TAG is set,
+        only routers whose ``tags`` list contains that value are included.
 
         Returns:
             List of router dictionaries from all sites.
         """
         devices: list[dict[str, Any]] = []
         sdwan_data = self.data_model.get("sdwan", {})
+        device_tag = os.environ.get("NAC_TEST_DEVICE_TAG")
 
         for site in sdwan_data.get("sites", []):
-            routers = site.get("routers", [])
-            devices.extend(routers)
+            for router in site.get("routers", []):
+                if device_tag:
+                    tags = router.get("tags") or []
+                    if device_tag not in tags:
+                        continue
+                devices.append(router)
 
         return devices
 

--- a/tests/unit/sdwan/test_api_test_base.py
+++ b/tests/unit/sdwan/test_api_test_base.py
@@ -98,3 +98,71 @@ class TestGetSDWANManagerClientHeaders:
 
         with pytest.raises(ValueError, match="Unsupported auth_method"):
             test_base.get_sdwan_manager_client()
+
+
+class TestGetDevicesFromDataModelTagFiltering:
+    """Test NAC_TEST_DEVICE_TAG filtering in get_devices_from_data_model()."""
+
+    @pytest.fixture
+    def tagged_instance(self) -> SDWANManagerTestBase:
+        """Create an instance with a data model containing tagged routers."""
+        instance = SDWANManagerTestBase.__new__(SDWANManagerTestBase)
+        instance.data_model = {
+            "sdwan": {
+                "sites": [
+                    {
+                        "id": 100,
+                        "routers": [
+                            {
+                                "tags": ["migration"],
+                                "device_variables": {
+                                    "system_ip": "10.0.0.1",
+                                    "site_id": 100,
+                                    "host_name": "tagged-router",
+                                },
+                            },
+                            {
+                                "device_variables": {
+                                    "system_ip": "10.0.0.2",
+                                    "site_id": 100,
+                                    "host_name": "untagged-router",
+                                },
+                            },
+                        ],
+                    },
+                ],
+            }
+        }
+        return instance
+
+    def test_no_tag_returns_all(
+        self,
+        tagged_instance: SDWANManagerTestBase,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Without NAC_TEST_DEVICE_TAG, all devices are returned."""
+        monkeypatch.delenv("NAC_TEST_DEVICE_TAG", raising=False)
+        devices = tagged_instance.get_devices_from_data_model()
+        assert len(devices) == 2
+
+    def test_tag_filters_devices(
+        self,
+        tagged_instance: SDWANManagerTestBase,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """With NAC_TEST_DEVICE_TAG, only matching devices are returned."""
+        monkeypatch.setenv("NAC_TEST_DEVICE_TAG", "migration")
+        devices = tagged_instance.get_devices_from_data_model()
+        assert len(devices) == 1
+        assert devices[0]["system_ip"] == "10.0.0.1"
+        assert devices[0]["hostname"] == "tagged-router"
+
+    def test_nonexistent_tag_returns_empty(
+        self,
+        tagged_instance: SDWANManagerTestBase,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A tag no router has returns empty list."""
+        monkeypatch.setenv("NAC_TEST_DEVICE_TAG", "nonexistent")
+        devices = tagged_instance.get_devices_from_data_model()
+        assert len(devices) == 0

--- a/tests/unit/sdwan/test_device_resolver.py
+++ b/tests/unit/sdwan/test_device_resolver.py
@@ -684,3 +684,112 @@ class TestErrorHandlingAndSkippedDevices:
         assert "system_hostname" in caplog.text
         assert "host_name" in caplog.text
         assert "ABC123" in caplog.text
+
+
+class TestDeviceTagFiltering:
+    """Test NAC_TEST_DEVICE_TAG filtering in navigate_to_devices()."""
+
+    @pytest.fixture  # type: ignore[untyped-decorator]
+    def tagged_data_model(self) -> dict[str, Any]:
+        """Data model with tags on some routers."""
+        return {
+            "sdwan": {
+                "management_ip_variable": "vpn511_int1_if_ipv4_address",
+                "sites": [
+                    {
+                        "name": "site1",
+                        "routers": [
+                            {
+                                "chassis_id": "TAGGED1",
+                                "tags": ["migration"],
+                                "device_variables": {
+                                    "system_hostname": "tagged-router1",
+                                    "vpn511_int1_if_ipv4_address": "10.1.1.1/32",
+                                },
+                            },
+                            {
+                                "chassis_id": "UNTAGGED1",
+                                "device_variables": {
+                                    "system_hostname": "untagged-router1",
+                                    "vpn511_int1_if_ipv4_address": "10.1.1.2/32",
+                                },
+                            },
+                        ],
+                    },
+                    {
+                        "name": "site2",
+                        "routers": [
+                            {
+                                "chassis_id": "TAGGED2",
+                                "tags": ["migration", "datacenter"],
+                                "device_variables": {
+                                    "system_hostname": "tagged-router2",
+                                    "vpn511_int1_if_ipv4_address": "10.2.1.1/32",
+                                },
+                            },
+                        ],
+                    },
+                ],
+            }
+        }
+
+    def test_no_tag_returns_all_devices(
+        self,
+        tagged_data_model: dict[str, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Without NAC_TEST_DEVICE_TAG, all routers are returned."""
+        monkeypatch.delenv("NAC_TEST_DEVICE_TAG", raising=False)
+        resolver = SDWANDeviceResolver(tagged_data_model)
+        devices = resolver.navigate_to_devices()
+        assert len(devices) == 3
+
+    def test_tag_filters_to_matching_devices(
+        self,
+        tagged_data_model: dict[str, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """With NAC_TEST_DEVICE_TAG set, only matching routers are returned."""
+        monkeypatch.setenv("NAC_TEST_DEVICE_TAG", "migration")
+        resolver = SDWANDeviceResolver(tagged_data_model)
+        devices = resolver.navigate_to_devices()
+        assert len(devices) == 2
+        chassis_ids = [d["chassis_id"] for d in devices]
+        assert "TAGGED1" in chassis_ids
+        assert "TAGGED2" in chassis_ids
+        assert "UNTAGGED1" not in chassis_ids
+
+    def test_tag_filters_to_specific_tag(
+        self,
+        tagged_data_model: dict[str, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Filtering by a tag only some routers have returns only those."""
+        monkeypatch.setenv("NAC_TEST_DEVICE_TAG", "datacenter")
+        resolver = SDWANDeviceResolver(tagged_data_model)
+        devices = resolver.navigate_to_devices()
+        assert len(devices) == 1
+        assert devices[0]["chassis_id"] == "TAGGED2"
+
+    def test_nonexistent_tag_returns_empty(
+        self,
+        tagged_data_model: dict[str, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A tag that no router has returns an empty list."""
+        monkeypatch.setenv("NAC_TEST_DEVICE_TAG", "nonexistent")
+        resolver = SDWANDeviceResolver(tagged_data_model)
+        devices = resolver.navigate_to_devices()
+        assert len(devices) == 0
+
+    def test_router_with_no_tags_field_excluded(
+        self,
+        tagged_data_model: dict[str, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Routers without a 'tags' field are excluded when filtering is active."""
+        monkeypatch.setenv("NAC_TEST_DEVICE_TAG", "migration")
+        resolver = SDWANDeviceResolver(tagged_data_model)
+        devices = resolver.navigate_to_devices()
+        chassis_ids = [d["chassis_id"] for d in devices]
+        assert "UNTAGGED1" not in chassis_ids


### PR DESCRIPTION
## Summary

Adds per-device tag filtering to both API and D2D test paths. When the `NAC_TEST_DEVICE_TAG` environment variable is set (threaded from nac-test's `--device-tag` CLI argument), `get_devices_from_data_model()` and `SDWANDeviceResolver.navigate_to_devices()` filter to only routers whose `tags` list in the data model contains the specified value.

## Motivation

A customer uses SD-WAN as Code to migrate sites into SD-WAN. Post-migration testing needs to validate only the migrated router(s) using the same test scripts that run fabric-wide. Without a filtering mechanism, this would require duplicating every test script — one set scoped to tagged devices, one set unscoped.

Although SD-WAN is the catalyst for this change and the first architecture where the pattern is implemented (driven by an immediate customer need for post-migration validation), the intent is for each architecture to adopt this mechanism to filter operational tests down to a user-defined subset of devices. The CLI argument and env var plumbing are architecture-agnostic; only the per-architecture base class/resolver needs to read the env var and filter accordingly.

The `tags` field already exists in the SD-WAN data model schema (`sdwan.sites[].routers[].tags`). This change makes the test framework tag-aware so that a single `nac-test` invocation with `--device-tag migration` runs the same scripts against only tagged devices.

## Changes

**`src/nac_test_pyats_common/sdwan/api_test_base.py`**
- `get_devices_from_data_model()` reads `NAC_TEST_DEVICE_TAG` from env
- When set, skips routers without that tag in their `tags` list
- When unset, returns all routers (no behavior change)

**`src/nac_test_pyats_common/sdwan/device_resolver.py`**
- `navigate_to_devices()` reads `NAC_TEST_DEVICE_TAG` from env
- Same filtering logic as above, applied to D2D device inventory

## Test Coverage

8 new unit tests (156 total pass):

| Area | Tests |
|------|-------|
| API filtering (`get_devices_from_data_model`) | `test_no_tag_returns_all`, `test_tag_filters_devices`, `test_nonexistent_tag_returns_empty` |
| D2D filtering (`navigate_to_devices`) | `test_no_tag_returns_all_devices`, `test_tag_filters_to_matching_devices`, `test_tag_filters_to_specific_tag`, `test_nonexistent_tag_returns_empty`, `test_router_with_no_tags_field_excluded` |

## Integration Testing

Validated end-to-end in SDWAN-as-Code-Demo against a live CML lab:
- `NAC_TEST_DEVICE_TAG=migration` with no tagged routers → all tests pass with 0 verification items (no API calls)
- `NAC_TEST_DEVICE_TAG=migration` with one tagged router → only that device's tests execute
- No env var set → all devices tested (regression-free)

## Dependencies

Requires companion PR in nac-test that adds the `--device-tag` CLI argument and threads `NAC_TEST_DEVICE_TAG` through the subprocess environment to both API and D2D execution paths.

## Notes

- Also includes a cherry-picked prerequisite commit adding `get_devices_from_data_model()` to `SDWANManagerTestBase` (was previously on a separate feature branch)
- The env var approach was chosen because pyATS tests run in subprocesses — Python objects cannot be passed across the process boundary
- Cross-architecture extensibility: future architectures (ACI, Catalyst Center) only need to add the same env var check in their resolver's `navigate_to_devices()` equivalent
