### PR TITLE
ci: run tests on all branch pushes, not just main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,6 @@ on:
   workflow_dispatch:
   pull_request:
   push:
-    branches:
-      - main
 
 jobs:
   security:


### PR DESCRIPTION
Removes the branch filter from the `push` trigger in the test workflow so CI runs on feature branch pushes — matching nac-test's behavior. Currently, the workflow only fires on pushes to `main` and on PRs, meaning contributors don't get feedback until they open a PR.

### Before
```yaml
push:
  branches:
    - main
```

### After
```yaml
push:
```