### PR TITLE
feat: add NX-OS SSH/D2D adapter for operational testing

### DIFF
--- a/src/nac_test_pyats_common/nxos/__init__.py
+++ b/src/nac_test_pyats_common/nxos/__init__.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2025 Daniel Schmidt
+
+"""NX-OS adapter module for NAC PyATS testing.
+
+This module provides NX-OS-specific classes for SSH/D2D operational testing
+against Nexus switches.
+
+Classes:
+    NXOSTestBase: Base class for NX-OS SSH/D2D tests.
+    NXOSDeviceResolver: Resolves device inventory from the NX-OS data model.
+
+Example:
+    >>> from nac_test_pyats_common.nxos import NXOSTestBase, NXOSDeviceResolver
+    >>>
+    >>> class VerifyVPCStatus(NXOSTestBase):
+    ...     @aetest.test
+    ...     def verify_vpc(self, steps, device):
+    ...         output = device.execute("show vpc")
+    ...         # verify VPC state
+"""
+
+from .device_resolver import NXOSDeviceResolver
+from .ssh_test_base import NXOSTestBase
+
+__all__ = [
+    "NXOSDeviceResolver",
+    "NXOSTestBase",
+]

--- a/src/nac_test_pyats_common/nxos/device_resolver.py
+++ b/src/nac_test_pyats_common/nxos/device_resolver.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2025 Daniel Schmidt
+
+"""NX-OS device resolver for SSH/D2D testing.
+
+This module provides the NXOSDeviceResolver class, which extends
+BaseDeviceResolver to implement NX-OS data model navigation.
+
+Device Fields Returned:
+    - hostname: Device name from nxos.devices[].name
+    - host: Management IP extracted from nxos.devices[].url
+    - os: Always 'nxos'
+    - platform: Always 'nexus'
+    - username: From NXOS_USERNAME environment variable
+    - password: From NXOS_PASSWORD environment variable
+"""
+
+import logging
+from typing import Any
+from urllib.parse import urlparse
+
+from nac_test_pyats_common.common import BaseDeviceResolver
+
+logger = logging.getLogger(__name__)
+
+
+class NXOSDeviceResolver(BaseDeviceResolver):
+    """NX-OS device resolver for D2D testing.
+
+    Navigates the NX-OS NAC schema (nxos.devices[]) to extract
+    device information for SSH testing.
+
+    Schema structure:
+        nxos:
+          devices:
+            - name: "N9K-1"
+              url: "https://10.48.161.104"
+              managed: true  # optional
+
+    Credentials:
+        Uses NXOS_USERNAME and NXOS_PASSWORD environment variables.
+
+    Example:
+        >>> resolver = NXOSDeviceResolver(data_model)
+        >>> devices = resolver.get_resolved_inventory()
+        >>> devices[0]["hostname"]
+        'N9K-1'
+        >>> devices[0]["host"]
+        '10.48.161.104'
+        >>> devices[0]["os"]
+        'nxos'
+    """
+
+    def get_architecture_name(self) -> str:
+        """Return the architecture identifier."""
+        return "nxos"
+
+    def get_schema_root_key(self) -> str:
+        """Return the top-level data model key."""
+        return "nxos"
+
+    def navigate_to_devices(self) -> list[dict[str, Any]]:
+        """Navigate nxos.devices[] in the data model."""
+        devices: list[dict[str, Any]] = self.data_model.get("nxos", {}).get(
+            "devices", []
+        )
+        return devices
+
+    def validate_device_data(self, device_data: dict[str, Any]) -> None:
+        """Skip devices where managed is explicitly False."""
+        if device_data.get("managed") is False:
+            raise ValueError("Device has managed=false, skipping")
+
+    def extract_hostname(self, device_data: dict[str, Any]) -> str:
+        """Extract device hostname from the name field."""
+        return str(device_data["name"])
+
+    def extract_host_ip(self, device_data: dict[str, Any]) -> str:
+        """Extract management IP from the device URL field.
+
+        The NX-OS data model stores the RESTCONF URL (e.g., "https://10.48.161.104").
+        We parse the hostname/IP from this URL.
+        """
+        url = device_data["url"]
+        parsed = urlparse(url)
+        host = parsed.hostname
+        if not host:
+            raise ValueError(f"Cannot extract host from URL: {url!r}")
+        return str(host)
+
+    def extract_os_platform_type(self, device_data: dict[str, Any]) -> dict[str, str]:
+        """Return Unicon os and platform for NX-OS devices."""
+        return {"os": "nxos", "platform": "nexus"}
+
+    def get_credential_env_vars(self) -> tuple[str, str]:
+        """Return credential environment variable names."""
+        return ("NXOS_USERNAME", "NXOS_PASSWORD")

--- a/src/nac_test_pyats_common/nxos/ssh_test_base.py
+++ b/src/nac_test_pyats_common/nxos/ssh_test_base.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2025 Daniel Schmidt
+
+"""NX-OS specific base test class for SSH/Direct-to-Device testing.
+
+This module provides the NXOSTestBase class, which extends the generic SSHTestBase
+to add NX-OS-specific functionality for device-to-device (D2D) testing.
+
+The class delegates device inventory resolution to NXOSDeviceResolver, which
+handles all NX-OS schema navigation and credential injection.
+
+Credentials:
+    NX-OS D2D tests connect directly to Nexus switches. Set these environment
+    variables:
+    - NXOS_USERNAME: SSH username for NX-OS devices
+    - NXOS_PASSWORD: SSH password for NX-OS devices
+"""
+
+import logging
+from typing import Any
+
+from nac_test.pyats_core.common.ssh_base_test import (
+    SSHTestBase,  # type: ignore[import-untyped]
+)
+
+from .device_resolver import NXOSDeviceResolver
+
+logger = logging.getLogger(__name__)
+
+
+class NXOSTestBase(SSHTestBase):  # type: ignore[misc]
+    """NX-OS-specific base test class for SSH/D2D testing.
+
+    This class extends SSHTestBase and implements the contract required by
+    nac-test's SSH execution engine. Device inventory resolution is fully
+    delegated to NXOSDeviceResolver.
+
+    Credentials:
+        NX-OS D2D tests require NXOS_USERNAME and NXOS_PASSWORD environment
+        variables.
+
+    Example:
+        class MyNXOSTest(NXOSTestBase):
+            @aetest.test
+            def verify_bgp_neighbors(self, steps, device):
+                # SSH-based verification logic here
+                pass
+    """
+
+    _last_resolver: "NXOSDeviceResolver | None" = None
+
+    @classmethod
+    def get_ssh_device_inventory(
+        cls, data_model: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        """Parse the NX-OS data model to retrieve the device inventory.
+
+        This method is the entry point called by nac-test's orchestrator.
+        All device inventory resolution is delegated to NXOSDeviceResolver,
+        which handles:
+        - Schema navigation (nxos.devices[])
+        - URL-to-IP extraction
+        - Credential injection (NXOS_USERNAME, NXOS_PASSWORD)
+
+        After calling this method, access cls._last_resolver.skipped_devices
+        to get information about devices that failed resolution.
+
+        Args:
+            data_model: The merged data model from nac-test containing all
+                configuration data with resolved variables.
+
+        Returns:
+            List of device dictionaries, each containing:
+            - hostname (str): Device name
+            - host (str): Management IP address for SSH connection
+            - os (str): Always "nxos"
+            - platform (str): Always "nexus"
+            - username (str): Environment variable reference
+            - password (str): Environment variable reference
+        """
+        resolver = NXOSDeviceResolver(data_model)
+        cls._last_resolver = resolver
+        return resolver.get_resolved_inventory()

--- a/tests/unit/nxos/__init__.py
+++ b/tests/unit/nxos/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2025 Daniel Schmidt
+
+# SPDX-License-Identifier: MPL-2.0

--- a/tests/unit/nxos/test_device_resolver.py
+++ b/tests/unit/nxos/test_device_resolver.py
@@ -1,0 +1,253 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2025 Daniel Schmidt
+
+# SPDX-License-Identifier: MPL-2.0
+
+"""Unit tests for NXOSDeviceResolver."""
+
+from typing import Any
+
+import pytest
+
+from nac_test_pyats_common.nxos.device_resolver import NXOSDeviceResolver
+
+
+@pytest.fixture
+def sample_data_model() -> dict[str, Any]:
+    """Provide a sample NX-OS data model for testing."""
+    return {
+        "nxos": {
+            "devices": [
+                {
+                    "name": "N9K-SPINE-1",
+                    "url": "https://10.1.1.1",
+                },
+                {
+                    "name": "N9K-LEAF-1",
+                    "url": "https://10.1.1.2",
+                },
+                {
+                    "name": "N9K-LEAF-2",
+                    "url": "https://10.1.1.3",
+                    "managed": True,
+                },
+            ]
+        }
+    }
+
+
+@pytest.fixture
+def data_model_with_unmanaged() -> dict[str, Any]:
+    """Data model containing a device with managed=false."""
+    return {
+        "nxos": {
+            "devices": [
+                {
+                    "name": "N9K-ACTIVE",
+                    "url": "https://10.1.1.1",
+                },
+                {
+                    "name": "N9K-UNMANAGED",
+                    "url": "https://10.1.1.2",
+                    "managed": False,
+                },
+            ]
+        }
+    }
+
+
+@pytest.fixture
+def empty_data_model() -> dict[str, Any]:
+    """Data model with no devices."""
+    return {"nxos": {"devices": []}}
+
+
+class TestNXOSDeviceResolverNavigation:
+    """Test schema navigation and device discovery."""
+
+    def test_navigate_to_devices(self, sample_data_model: dict[str, Any]) -> None:
+        """Navigate to devices."""
+        resolver = NXOSDeviceResolver(sample_data_model)
+        devices = resolver.navigate_to_devices()
+        assert len(devices) == 3
+        assert devices[0]["name"] == "N9K-SPINE-1"
+        assert devices[1]["name"] == "N9K-LEAF-1"
+
+    def test_navigate_empty_data_model(self, empty_data_model: dict[str, Any]) -> None:
+        """Navigate empty data model."""
+        resolver = NXOSDeviceResolver(empty_data_model)
+        devices = resolver.navigate_to_devices()
+        assert devices == []
+
+    def test_navigate_missing_nxos_key(self) -> None:
+        """Navigate missing nxos key."""
+        resolver = NXOSDeviceResolver({})
+        devices = resolver.navigate_to_devices()
+        assert devices == []
+
+    def test_navigate_missing_devices_key(self) -> None:
+        """Navigate missing devices key."""
+        resolver = NXOSDeviceResolver({"nxos": {}})
+        devices = resolver.navigate_to_devices()
+        assert devices == []
+
+
+class TestNXOSDeviceResolverExtraction:
+    """Test field extraction from device data."""
+
+    def test_extract_hostname(self, sample_data_model: dict[str, Any]) -> None:
+        """Extract hostname."""
+        resolver = NXOSDeviceResolver(sample_data_model)
+        device = sample_data_model["nxos"]["devices"][0]
+        assert resolver.extract_hostname(device) == "N9K-SPINE-1"
+
+    def test_extract_host_ip_https(self, sample_data_model: dict[str, Any]) -> None:
+        """Extract host ip https."""
+        resolver = NXOSDeviceResolver(sample_data_model)
+        device = {"name": "test", "url": "https://10.48.161.104"}
+        assert resolver.extract_host_ip(device) == "10.48.161.104"
+
+    def test_extract_host_ip_with_port(self, sample_data_model: dict[str, Any]) -> None:
+        """Extract host ip with port."""
+        resolver = NXOSDeviceResolver(sample_data_model)
+        device = {"name": "test", "url": "https://10.48.161.104:443"}
+        assert resolver.extract_host_ip(device) == "10.48.161.104"
+
+    def test_extract_host_ip_http(self, sample_data_model: dict[str, Any]) -> None:
+        """Extract host ip http."""
+        resolver = NXOSDeviceResolver(sample_data_model)
+        device = {"name": "test", "url": "http://192.168.1.1"}
+        assert resolver.extract_host_ip(device) == "192.168.1.1"
+
+    def test_extract_host_ip_invalid_url(
+        self, sample_data_model: dict[str, Any]
+    ) -> None:
+        """Extract host ip invalid url."""
+        resolver = NXOSDeviceResolver(sample_data_model)
+        device = {"name": "test", "url": "not-a-url"}
+        with pytest.raises(ValueError, match="Cannot extract host from URL"):
+            resolver.extract_host_ip(device)
+
+    def test_extract_os_platform_type(self, sample_data_model: dict[str, Any]) -> None:
+        """Extract os platform type."""
+        resolver = NXOSDeviceResolver(sample_data_model)
+        device = sample_data_model["nxos"]["devices"][0]
+        result = resolver.extract_os_platform_type(device)
+        assert result == {"os": "nxos", "platform": "nexus"}
+
+    def test_get_architecture_name(self, sample_data_model: dict[str, Any]) -> None:
+        """Get architecture name."""
+        resolver = NXOSDeviceResolver(sample_data_model)
+        assert resolver.get_architecture_name() == "nxos"
+
+    def test_get_schema_root_key(self, sample_data_model: dict[str, Any]) -> None:
+        """Get schema root key."""
+        resolver = NXOSDeviceResolver(sample_data_model)
+        assert resolver.get_schema_root_key() == "nxos"
+
+    def test_get_credential_env_vars(self, sample_data_model: dict[str, Any]) -> None:
+        """Get credential env vars."""
+        resolver = NXOSDeviceResolver(sample_data_model)
+        assert resolver.get_credential_env_vars() == (
+            "NXOS_USERNAME",
+            "NXOS_PASSWORD",
+        )
+
+
+class TestNXOSDeviceResolverValidation:
+    """Test device validation and filtering."""
+
+    def test_skip_unmanaged_devices(
+        self, data_model_with_unmanaged: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Skip unmanaged devices."""
+        monkeypatch.setenv("NXOS_USERNAME", "admin")
+        monkeypatch.setenv("NXOS_PASSWORD", "password")
+
+        resolver = NXOSDeviceResolver(data_model_with_unmanaged)
+        devices = resolver.get_resolved_inventory()
+
+        assert len(devices) == 1
+        assert devices[0]["hostname"] == "N9K-ACTIVE"
+        assert len(resolver.skipped_devices) == 1
+        assert resolver.skipped_devices[0]["device_id"] == "N9K-UNMANAGED"
+
+    def test_managed_true_not_skipped(
+        self, sample_data_model: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Managed true not skipped."""
+        monkeypatch.setenv("NXOS_USERNAME", "admin")
+        monkeypatch.setenv("NXOS_PASSWORD", "password")
+
+        resolver = NXOSDeviceResolver(sample_data_model)
+        devices = resolver.get_resolved_inventory()
+
+        assert len(devices) == 3
+
+    def test_managed_absent_not_skipped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Managed absent not skipped."""
+        monkeypatch.setenv("NXOS_USERNAME", "admin")
+        monkeypatch.setenv("NXOS_PASSWORD", "password")
+
+        data_model = {
+            "nxos": {"devices": [{"name": "N9K-1", "url": "https://10.1.1.1"}]}
+        }
+        resolver = NXOSDeviceResolver(data_model)
+        devices = resolver.get_resolved_inventory()
+        assert len(devices) == 1
+
+
+class TestNXOSDeviceResolverCredentials:
+    """Test credential injection."""
+
+    def test_credentials_injected(
+        self, sample_data_model: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Credentials injected."""
+        monkeypatch.setenv("NXOS_USERNAME", "admin")
+        monkeypatch.setenv("NXOS_PASSWORD", "secret")
+
+        resolver = NXOSDeviceResolver(sample_data_model)
+        devices = resolver.get_resolved_inventory()
+
+        for device in devices:
+            assert device["username"] == "%ENV{NXOS_USERNAME}"
+            assert device["password"] == "%ENV{NXOS_PASSWORD}"
+
+    def test_missing_credentials_raises(
+        self, sample_data_model: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Missing credentials raises."""
+        monkeypatch.delenv("NXOS_USERNAME", raising=False)
+        monkeypatch.delenv("NXOS_PASSWORD", raising=False)
+
+        resolver = NXOSDeviceResolver(sample_data_model)
+        with pytest.raises(ValueError, match="Missing required credential"):
+            resolver.get_resolved_inventory()
+
+
+class TestNXOSDeviceResolverFullInventory:
+    """Test full inventory resolution end-to-end."""
+
+    def test_full_resolution(
+        self, sample_data_model: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Full resolution."""
+        monkeypatch.setenv("NXOS_USERNAME", "admin")
+        monkeypatch.setenv("NXOS_PASSWORD", "password")
+
+        resolver = NXOSDeviceResolver(sample_data_model)
+        devices = resolver.get_resolved_inventory()
+
+        assert len(devices) == 3
+
+        assert devices[0]["hostname"] == "N9K-SPINE-1"
+        assert devices[0]["host"] == "10.1.1.1"
+        assert devices[0]["os"] == "nxos"
+        assert devices[0]["platform"] == "nexus"
+
+        assert devices[1]["hostname"] == "N9K-LEAF-1"
+        assert devices[1]["host"] == "10.1.1.2"
+
+        assert devices[2]["hostname"] == "N9K-LEAF-2"
+        assert devices[2]["host"] == "10.1.1.3"


### PR DESCRIPTION
## Summary

- Adds NX-OS device resolver and SSH test base for D2D (device-to-device) operational testing
- Enables NX-OS test scripts to inherit from `NXOSTestBase` for SSH-based state verification
- Device inventory resolved from `nxos.devices[]` in the NAC data model

## New Components

| File | Purpose |
|------|---------|
| `src/nac_test_pyats_common/nxos/__init__.py` | Module exports |
| `src/nac_test_pyats_common/nxos/device_resolver.py` | `NXOSDeviceResolver` — navigates `nxos.devices[].{name, url}`, extracts hostname and IP from URL |
| `src/nac_test_pyats_common/nxos/ssh_test_base.py` | `NXOSTestBase(SSHTestBase)` — thin wrapper delegating to resolver |
| `tests/unit/nxos/test_device_resolver.py` | 239 lines of unit tests |

## Design

- Follows the same `BaseDeviceResolver` → architecture-specific resolver pattern as SDWAN
- Credentials via `NXOS_USERNAME` / `NXOS_PASSWORD` env vars
- Returns `os='nxos'` for Unicon connection
- Extracts management IP from `url` field (strips `https://` prefix)

## Test plan

- [x] Unit tests pass (239 lines covering navigation, extraction, credentials, edge cases)
- [x] Tested end-to-end against live Nexus 9000 switches (124+ operational test scripts)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: claude-opus-4-6
- **AI Contribution**: ~80%
- **AI Reason**: adapter implementation + unit tests
- **Human Oversight**: Code reviewed and tested by Christopher Hart