### PR TITLE
feat: add FTD SSH/D2D adapter for operational testing

### DIFF
--- a/src/nac_test_pyats_common/fmc/__init__.py
+++ b/src/nac_test_pyats_common/fmc/__init__.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2025 Daniel Schmidt
+
+"""FMC/FTD adapter module for NAC PyATS testing.
+
+This module provides classes for SSH/D2D operational testing against
+Cisco Firepower Threat Defense devices managed by FMC.
+
+Classes:
+    FTDTestBase: Base class for FTD SSH/D2D tests.
+    FTDDeviceResolver: Resolves FTD device inventory from FMC data model.
+
+Example (SSH test against FTD):
+    >>> from nac_test_pyats_common.fmc import FTDTestBase
+    >>>
+    >>> class VerifyFailoverStatus(FTDTestBase):
+    ...     @aetest.test
+    ...     def verify_failover(self, steps, device):
+    ...         output = device.execute("show failover")
+    ...         # verify failover state
+"""
+
+from .device_resolver import FTDDeviceResolver
+from .ssh_test_base import FTDTestBase
+
+__all__ = [
+    "FTDDeviceResolver",
+    "FTDTestBase",
+]

--- a/src/nac_test_pyats_common/fmc/device_resolver.py
+++ b/src/nac_test_pyats_common/fmc/device_resolver.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2025 Daniel Schmidt
+
+# SPDX-License-Identifier: MPL-2.0
+
+"""FTD device resolver for SSH/D2D testing.
+
+This module provides the FTDDeviceResolver class, which extends
+BaseDeviceResolver to navigate the FMC data model and extract
+FTD device information for SSH-based operational testing.
+
+Device Fields Returned:
+    - hostname: Device name from fmc.domains[].devices.devices[].name
+    - host: Management IP from fmc.domains[].devices.devices[].host
+    - os: Always 'fxos' (Firepower eXtensible OS)
+    - platform: Always 'ftd' (Firepower Threat Defense)
+    - username: From FTD_USERNAME environment variable
+    - password: From FTD_PASSWORD environment variable
+
+Note:
+    FTD SSH credentials are SEPARATE from FMC controller credentials.
+    FMC_USERNAME/FMC_PASSWORD are for the FMC REST API.
+    FTD_USERNAME/FTD_PASSWORD are for SSH access to FTD devices.
+"""
+
+import logging
+from typing import Any
+
+from nac_test_pyats_common.common import BaseDeviceResolver
+
+logger = logging.getLogger(__name__)
+
+
+class FTDDeviceResolver(BaseDeviceResolver):
+    """FTD device resolver for D2D testing.
+
+    Navigates the FMC NAC data model (fmc.domains[].devices.devices[])
+    to extract FTD device information for SSH testing. Devices are
+    flattened across all FMC domains into a single inventory.
+
+    Schema structure:
+        fmc:
+          domains:
+            - name: "Global"
+              devices:
+                devices:
+                  - name: "FTD-FW1"
+                    host: "10.1.1.100"
+                  - name: "FTD-FW2"
+                    host: "10.1.1.101"
+            - name: "Branch"
+              devices:
+                devices:
+                  - name: "FTD-BR1"
+                    host: "10.2.1.100"
+
+    Credentials:
+        Uses FTD_USERNAME and FTD_PASSWORD environment variables.
+        These are for SSH access to FTD devices, NOT for the FMC controller.
+
+    Example:
+        >>> resolver = FTDDeviceResolver(data_model)
+        >>> devices = resolver.get_resolved_inventory()
+        >>> devices[0]["hostname"]
+        'FTD-FW1'
+        >>> devices[0]["os"]
+        'fxos'
+        >>> devices[0]["platform"]
+        'ftd'
+    """
+
+    def get_architecture_name(self) -> str:
+        """Return the architecture identifier."""
+        return "fmc"
+
+    def get_schema_root_key(self) -> str:
+        """Return the top-level data model key."""
+        return "fmc"
+
+    def navigate_to_devices(self) -> list[dict[str, Any]]:
+        """Flatten all FTD devices across FMC domains.
+
+        Iterates fmc.domains[].devices.devices[] and collects all devices
+        into a single flat list regardless of which domain they belong to.
+        """
+        devices: list[dict[str, Any]] = []
+        fmc_data = self.data_model.get("fmc", {})
+        domains = fmc_data.get("domains", [])
+
+        for domain in domains:
+            domain_devices = domain.get("devices", {})
+            device_list = domain_devices.get("devices", [])
+            devices.extend(device_list)
+
+        return devices
+
+    def extract_hostname(self, device_data: dict[str, Any]) -> str:
+        """Extract device hostname from the name field."""
+        return str(device_data["name"])
+
+    def extract_host_ip(self, device_data: dict[str, Any]) -> str:
+        """Extract management IP from the host field.
+
+        The FMC data model stores the device's management IP/hostname
+        directly in the 'host' field (mapped from FMC API's hostName).
+        """
+        host = device_data.get("host")
+        if not host:
+            raise ValueError("Device has no 'host' field for management IP")
+        return str(host)
+
+    def extract_os_platform_type(self, device_data: dict[str, Any]) -> dict[str, str]:
+        """Return Unicon os and platform for FTD devices."""
+        return {"os": "fxos", "platform": "ftd"}
+
+    def get_credential_env_vars(self) -> tuple[str, str]:
+        """Return credential environment variable names."""
+        return ("FTD_USERNAME", "FTD_PASSWORD")

--- a/src/nac_test_pyats_common/fmc/ssh_test_base.py
+++ b/src/nac_test_pyats_common/fmc/ssh_test_base.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2025 Daniel Schmidt
+
+# SPDX-License-Identifier: MPL-2.0
+
+"""FTD-specific base test class for SSH/Direct-to-Device testing.
+
+This module provides the FTDTestBase class, which extends the generic SSHTestBase
+to add FTD-specific functionality for device-to-device (D2D) testing.
+
+The class delegates device inventory resolution to FTDDeviceResolver, which
+handles FMC data model navigation and credential injection.
+
+Credentials:
+    FTD D2D tests connect to Firepower Threat Defense devices, NOT the FMC
+    controller. Set these environment variables:
+    - FTD_USERNAME: SSH username for FTD devices
+    - FTD_PASSWORD: SSH password for FTD devices
+
+PyATS/Unicon Configuration:
+    FTD devices use os='fxos' and platform='ftd', which activates the
+    Unicon FTD plugin with its multi-state CLI (chassis, fxos, ftd_console,
+    ftd_expert). The plugin handles state transitions automatically.
+"""
+
+import logging
+from typing import Any
+
+from nac_test.pyats_core.common.ssh_base_test import (
+    SSHTestBase,  # type: ignore[import-untyped]
+)
+
+from .device_resolver import FTDDeviceResolver
+
+logger = logging.getLogger(__name__)
+
+
+class FTDTestBase(SSHTestBase):  # type: ignore[misc]
+    """FTD-specific base test class for SSH/D2D testing.
+
+    This class extends SSHTestBase and implements the contract required by
+    nac-test's SSH execution engine. Device inventory resolution is fully
+    delegated to FTDDeviceResolver.
+
+    Credentials:
+        FTD D2D tests require FTD_USERNAME and FTD_PASSWORD environment
+        variables (NOT FMC_* which are for the controller API).
+
+    Example:
+        class MyFTDTest(FTDTestBase):
+            @aetest.test
+            def verify_failover_status(self, steps, device):
+                # SSH-based verification on FTD device
+                output = device.execute("show failover")
+                # process output...
+    """
+
+    _last_resolver: "FTDDeviceResolver | None" = None
+
+    @classmethod
+    def get_ssh_device_inventory(
+        cls, data_model: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        """Parse the FMC data model to retrieve FTD device inventory.
+
+        This method is the entry point called by nac-test's orchestrator.
+        All device inventory resolution is delegated to FTDDeviceResolver,
+        which handles:
+        - Schema navigation (fmc.domains[].devices.devices[])
+        - Flattening devices across all FMC domains
+        - Credential injection (FTD_USERNAME, FTD_PASSWORD)
+
+        After calling this method, access cls._last_resolver.skipped_devices
+        to get information about devices that failed resolution.
+
+        Args:
+            data_model: The merged data model from nac-test containing all
+                FMC configuration data with resolved variables.
+
+        Returns:
+            List of device dictionaries, each containing:
+            - hostname (str): FTD device name
+            - host (str): Management IP address for SSH connection
+            - os (str): Always "fxos"
+            - platform (str): Always "ftd"
+            - username (str): Environment variable reference
+            - password (str): Environment variable reference
+        """
+        resolver = FTDDeviceResolver(data_model)
+        cls._last_resolver = resolver
+        return resolver.get_resolved_inventory()

--- a/tests/unit/fmc/__init__.py
+++ b/tests/unit/fmc/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2025 Daniel Schmidt
+
+# SPDX-License-Identifier: MPL-2.0

--- a/tests/unit/fmc/test_device_resolver.py
+++ b/tests/unit/fmc/test_device_resolver.py
@@ -1,0 +1,227 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2025 Daniel Schmidt
+
+# SPDX-License-Identifier: MPL-2.0
+
+"""Unit tests for FTDDeviceResolver."""
+
+from typing import Any
+
+import pytest
+
+from nac_test_pyats_common.fmc.device_resolver import FTDDeviceResolver
+
+
+@pytest.fixture
+def sample_data_model() -> dict[str, Any]:
+    """FMC data model with devices across multiple domains."""
+    return {
+        "fmc": {
+            "domains": [
+                {
+                    "name": "Global",
+                    "devices": {
+                        "devices": [
+                            {"name": "FTD-DC-FW1", "host": "10.1.1.100"},
+                            {"name": "FTD-DC-FW2", "host": "10.1.1.101"},
+                        ]
+                    },
+                },
+                {
+                    "name": "Branch",
+                    "devices": {
+                        "devices": [
+                            {"name": "FTD-BR-FW1", "host": "10.2.1.100"},
+                        ]
+                    },
+                },
+            ]
+        }
+    }
+
+
+@pytest.fixture
+def single_domain_data_model() -> dict[str, Any]:
+    """FMC data model with a single domain."""
+    return {
+        "fmc": {
+            "domains": [
+                {
+                    "name": "Global",
+                    "devices": {
+                        "devices": [
+                            {"name": "M1-FPR4215-1", "host": "9.1.29.50"},
+                            {"name": "M1-FPR4215-2", "host": "9.1.29.51"},
+                        ]
+                    },
+                }
+            ]
+        }
+    }
+
+
+@pytest.fixture
+def empty_data_model() -> dict[str, Any]:
+    """Data model with no FMC data."""
+    return {}
+
+
+class TestFTDDeviceResolverNavigation:
+    """Test schema navigation and device flattening."""
+
+    def test_navigate_flattens_across_domains(
+        self, sample_data_model: dict[str, Any]
+    ) -> None:
+        """Navigate flattens across domains."""
+        resolver = FTDDeviceResolver(sample_data_model)
+        devices = resolver.navigate_to_devices()
+        assert len(devices) == 3
+        assert devices[0]["name"] == "FTD-DC-FW1"
+        assert devices[1]["name"] == "FTD-DC-FW2"
+        assert devices[2]["name"] == "FTD-BR-FW1"
+
+    def test_navigate_single_domain(
+        self, single_domain_data_model: dict[str, Any]
+    ) -> None:
+        """Navigate single domain."""
+        resolver = FTDDeviceResolver(single_domain_data_model)
+        devices = resolver.navigate_to_devices()
+        assert len(devices) == 2
+
+    def test_navigate_missing_fmc_key(self, empty_data_model: dict[str, Any]) -> None:
+        """Navigate missing fmc key."""
+        resolver = FTDDeviceResolver(empty_data_model)
+        devices = resolver.navigate_to_devices()
+        assert devices == []
+
+    def test_navigate_empty_domains(self) -> None:
+        """Navigate empty domains."""
+        resolver = FTDDeviceResolver({"fmc": {"domains": []}})
+        devices = resolver.navigate_to_devices()
+        assert devices == []
+
+    def test_navigate_domain_missing_devices_key(self) -> None:
+        """Navigate domain missing devices key."""
+        resolver = FTDDeviceResolver({"fmc": {"domains": [{"name": "Global"}]}})
+        devices = resolver.navigate_to_devices()
+        assert devices == []
+
+    def test_navigate_domain_empty_device_list(self) -> None:
+        """Navigate domain empty device list."""
+        resolver = FTDDeviceResolver(
+            {"fmc": {"domains": [{"name": "Global", "devices": {"devices": []}}]}}
+        )
+        devices = resolver.navigate_to_devices()
+        assert devices == []
+
+
+class TestFTDDeviceResolverExtraction:
+    """Test field extraction from device data."""
+
+    def test_extract_hostname(self, sample_data_model: dict[str, Any]) -> None:
+        """Extract hostname."""
+        resolver = FTDDeviceResolver(sample_data_model)
+        device = {"name": "FTD-DC-FW1", "host": "10.1.1.100"}
+        assert resolver.extract_hostname(device) == "FTD-DC-FW1"
+
+    def test_extract_host_ip(self, sample_data_model: dict[str, Any]) -> None:
+        """Extract host ip."""
+        resolver = FTDDeviceResolver(sample_data_model)
+        device = {"name": "FTD-DC-FW1", "host": "10.1.1.100"}
+        assert resolver.extract_host_ip(device) == "10.1.1.100"
+
+    def test_extract_host_ip_missing_raises(
+        self, sample_data_model: dict[str, Any]
+    ) -> None:
+        """Extract host ip missing raises."""
+        resolver = FTDDeviceResolver(sample_data_model)
+        device = {"name": "FTD-NO-HOST"}
+        with pytest.raises(ValueError, match="no 'host' field"):
+            resolver.extract_host_ip(device)
+
+    def test_extract_host_ip_empty_raises(
+        self, sample_data_model: dict[str, Any]
+    ) -> None:
+        """Extract host ip empty raises."""
+        resolver = FTDDeviceResolver(sample_data_model)
+        device = {"name": "FTD-EMPTY", "host": ""}
+        with pytest.raises(ValueError, match="no 'host' field"):
+            resolver.extract_host_ip(device)
+
+    def test_extract_os_platform_type(self, sample_data_model: dict[str, Any]) -> None:
+        """Extract os platform type."""
+        resolver = FTDDeviceResolver(sample_data_model)
+        device = {"name": "FTD-DC-FW1", "host": "10.1.1.100"}
+        result = resolver.extract_os_platform_type(device)
+        assert result == {"os": "fxos", "platform": "ftd"}
+
+    def test_get_architecture_name(self, sample_data_model: dict[str, Any]) -> None:
+        """Get architecture name."""
+        resolver = FTDDeviceResolver(sample_data_model)
+        assert resolver.get_architecture_name() == "fmc"
+
+    def test_get_schema_root_key(self, sample_data_model: dict[str, Any]) -> None:
+        """Get schema root key."""
+        resolver = FTDDeviceResolver(sample_data_model)
+        assert resolver.get_schema_root_key() == "fmc"
+
+    def test_get_credential_env_vars(self, sample_data_model: dict[str, Any]) -> None:
+        """Get credential env vars."""
+        resolver = FTDDeviceResolver(sample_data_model)
+        assert resolver.get_credential_env_vars() == ("FTD_USERNAME", "FTD_PASSWORD")
+
+
+class TestFTDDeviceResolverCredentials:
+    """Test credential injection."""
+
+    def test_credentials_injected(
+        self, single_domain_data_model: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Credentials injected."""
+        monkeypatch.setenv("FTD_USERNAME", "admin")
+        monkeypatch.setenv("FTD_PASSWORD", "C1sco12345")
+
+        resolver = FTDDeviceResolver(single_domain_data_model)
+        devices = resolver.get_resolved_inventory()
+
+        for device in devices:
+            assert device["username"] == "%ENV{FTD_USERNAME}"
+            assert device["password"] == "%ENV{FTD_PASSWORD}"
+
+    def test_missing_credentials_raises(
+        self, single_domain_data_model: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Missing credentials raises."""
+        monkeypatch.delenv("FTD_USERNAME", raising=False)
+        monkeypatch.delenv("FTD_PASSWORD", raising=False)
+
+        resolver = FTDDeviceResolver(single_domain_data_model)
+        with pytest.raises(ValueError, match="Missing required credential"):
+            resolver.get_resolved_inventory()
+
+
+class TestFTDDeviceResolverFullInventory:
+    """Test full inventory resolution end-to-end."""
+
+    def test_full_resolution_multi_domain(
+        self, sample_data_model: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Full resolution multi domain."""
+        monkeypatch.setenv("FTD_USERNAME", "admin")
+        monkeypatch.setenv("FTD_PASSWORD", "password")
+
+        resolver = FTDDeviceResolver(sample_data_model)
+        devices = resolver.get_resolved_inventory()
+
+        assert len(devices) == 3
+
+        assert devices[0]["hostname"] == "FTD-DC-FW1"
+        assert devices[0]["host"] == "10.1.1.100"
+        assert devices[0]["os"] == "fxos"
+        assert devices[0]["platform"] == "ftd"
+
+        assert devices[1]["hostname"] == "FTD-DC-FW2"
+        assert devices[1]["host"] == "10.1.1.101"
+
+        assert devices[2]["hostname"] == "FTD-BR-FW1"
+        assert devices[2]["host"] == "10.2.1.100"


### PR DESCRIPTION
## Summary

- Adds FTD device resolver and SSH test base for D2D operational testing against Cisco Firepower Threat Defense devices
- Enables test scripts to inherit from `FTDTestBase` for SSH-based state verification
- Device inventory resolved from `fmc.domains[].devices.devices[]` in the NAC data model

## New Components

| File | Purpose |
|------|---------|
| `src/nac_test_pyats_common/fmc/__init__.py` | Module exports (`FTDTestBase`, `FTDDeviceResolver`) |
| `src/nac_test_pyats_common/fmc/device_resolver.py` | `FTDDeviceResolver` — navigates `fmc.domains[].devices.devices[]`, flattens across domains |
| `src/nac_test_pyats_common/fmc/ssh_test_base.py` | `FTDTestBase(SSHTestBase)` — thin wrapper for FTD SSH tests |
| `tests/unit/fmc/test_device_resolver.py` | Unit tests (213 lines) |

## Design

- Separate credentials: `FTD_USERNAME` / `FTD_PASSWORD` (distinct from FMC controller creds)
- Returns `os='fxos'`, `platform='ftd'` for Unicon FTD plugin
- Flattens devices across all FMC domains into a single inventory
- Host IP from `fmc.domains[].devices.devices[].host` field

## Test plan

- [x] Unit tests pass (17 tests)
- [x] Tested end-to-end against live FPR4215 HA pair (82 operational test scripts, learn + verify)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: claude-opus-4-6
- **AI Contribution**: ~80%
- **AI Reason**: adapter implementation + unit tests
- **Human Oversight**: Code reviewed and tested by Christopher Hart