### PR TITLE
feat: add FMC API adapter for operational testing

### DIFF
--- a/src/nac_test_pyats_common/fmc/__init__.py
+++ b/src/nac_test_pyats_common/fmc/__init__.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2025 Daniel Schmidt
+
+# SPDX-License-Identifier: MPL-2.0
+
+"""FMC (Firepower Management Center) adapter module for NAC PyATS testing.
+
+This module provides FMC-specific classes for both API-based and SSH/D2D
+operational testing against Cisco Firepower Management Center controllers
+and the FTD devices they manage.
+
+Classes:
+    FMCAuth: Authentication handler for FMC token-based auth.
+    FMCTestBase: Base class for FMC API tests.
+    FTDTestBase: Base class for FTD SSH/D2D tests.
+    FTDDeviceResolver: Resolves FTD device inventory from FMC data model.
+
+Example (API test against FMC):
+    >>> from nac_test_pyats_common.fmc import FMCTestBase
+    >>>
+    >>> class VerifyDeviceStatus(FMCTestBase):
+    ...     async def get_items_to_verify(self):
+    ...         return [{"device_id": "abc123"}]
+    ...
+    ...     async def verify_item(self, semaphore, client, context):
+    ...         device_id = context['device_id']
+    ...         resp = await client.get(f"/devices/devicerecords/{device_id}")
+    ...         # verify device state
+
+Example (SSH test against FTD):
+    >>> from nac_test_pyats_common.fmc import FTDTestBase
+    >>>
+    >>> class VerifyFailoverStatus(FTDTestBase):
+    ...     @aetest.test
+    ...     def verify_failover(self, steps, device):
+    ...         output = device.execute("show failover")
+    ...         # verify failover state
+"""
+
+from .api_test_base import FMCTestBase
+from .auth import FMCAuth
+from .device_resolver import FTDDeviceResolver
+from .ssh_test_base import FTDTestBase
+
+__all__ = [
+    "FMCAuth",
+    "FMCTestBase",
+    "FTDDeviceResolver",
+    "FTDTestBase",
+]

--- a/src/nac_test_pyats_common/fmc/api_test_base.py
+++ b/src/nac_test_pyats_common/fmc/api_test_base.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2025 Daniel Schmidt
+
+# SPDX-License-Identifier: MPL-2.0
+
+"""FMC-specific base test class for API testing.
+
+This module provides the FMCTestBase class, which extends the generic NACTestBase
+to add FMC-specific functionality for testing Firepower Management Center
+controllers. It handles token-based authentication, client configuration,
+and provides a standardized interface for running asynchronous verification tests.
+
+The class integrates with PyATS/Genie test frameworks and provides automatic
+API call tracking for enhanced HTML reporting.
+"""
+
+import asyncio
+from typing import Any
+
+import httpx
+from nac_test.pyats_core.common.base_test import (
+    NACTestBase,  # type: ignore[import-untyped]
+)
+from pyats import aetest  # type: ignore[import-untyped]
+
+from .auth import FMCAuth
+
+
+class FMCTestBase(NACTestBase):  # type: ignore[misc]
+    """Base class for FMC API tests with enhanced reporting.
+
+    This class extends the generic NACTestBase to provide FMC-specific
+    functionality including token-based authentication (X-auth-access-token
+    header), domain-scoped API paths, API call tracking for HTML reports,
+    and wrapped HTTP client for automatic response capture.
+
+    The class follows the same pattern as APICTestBase and SDWANManagerTestBase
+    for consistency across NAC architecture adapters.
+
+    Attributes:
+        auth_data (dict): FMC authentication data containing the access token
+            and domain UUID obtained during setup.
+        domain_uuid (str): FMC domain UUID for API path construction.
+        client (httpx.AsyncClient | None): Wrapped async HTTP client configured
+            for FMC. Initialized to None, set during run_async_verification_test().
+        controller_url (str): Base URL of the FMC controller (inherited).
+
+    Example:
+        class MyFMCTest(FMCTestBase):
+            async def get_items_to_verify(self):
+                return [{'device_id': 'abc123'}, {'device_id': 'def456'}]
+
+            async def verify_item(self, semaphore, client, context):
+                # Custom verification logic querying FMC API
+                pass
+
+            @aetest.test
+            def verify_devices(self, steps):
+                self.run_async_verification_test(steps)
+    """
+
+    client: httpx.AsyncClient | None = None
+    auth_data: dict[str, Any]
+    domain_uuid: str
+
+    @aetest.setup  # type: ignore[misc, untyped-decorator]
+    def setup(self) -> None:
+        """Setup method that extends the generic base class setup.
+
+        Initializes the FMC test environment by:
+        1. Calling the parent class setup method
+        2. Obtaining FMC authentication token and domain UUID
+
+        Note: Client creation is deferred to run_async_verification_test() to avoid
+        macOS fork() issues with httpx/SSL.
+        """
+        super().setup()
+
+        try:
+            self.auth_data = FMCAuth.get_auth()
+            self.domain_uuid = self.auth_data.get("domain_uuid", "")
+        except (RuntimeError, ValueError) as e:
+            self.auth_data = {}
+            self.domain_uuid = ""
+            self.failed(f"Authentication failed: {e}")
+            return
+
+    def get_fmc_client(self) -> httpx.AsyncClient:
+        """Get an httpx async client configured for FMC with response tracking.
+
+        Creates an HTTP client configured for FMC API communication with
+        authentication headers, domain-scoped base URL, and automatic response
+        tracking for HTML report generation.
+
+        Returns:
+            httpx.AsyncClient configured with FMC authentication and base URL,
+            wrapped for automatic API call tracking.
+        """
+        base_url = self.controller_url.rstrip("/")
+        if self.domain_uuid:
+            base_url = f"{base_url}/api/fmc_config/v1/domain/{self.domain_uuid}"
+        else:
+            base_url = f"{base_url}/api/fmc_config/v1"
+
+        headers = {
+            "X-auth-access-token": self.auth_data["access_token"],
+            "Content-Type": "application/json",
+        }
+
+        client = self.pool.get_client(base_url=base_url, headers=headers, verify=False)
+
+        return self.wrap_client_for_tracking(client, device_name="FMC")  # type: ignore[no-any-return]
+
+    def run_async_verification_test(self, steps: Any) -> None:
+        """Execute asynchronous verification tests with PyATS step tracking.
+
+        Creates an event loop, builds the FMC client, runs async verification,
+        processes results, and ensures cleanup.
+
+        Args:
+            steps: PyATS steps object for test reporting and step management.
+        """
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            self.client = self.get_fmc_client()
+            results = loop.run_until_complete(self.run_verification_async())
+            self.process_results_smart(results, steps)
+        finally:
+            if self.client is not None:
+                loop.run_until_complete(self.client.aclose())
+            loop.close()

--- a/src/nac_test_pyats_common/fmc/auth.py
+++ b/src/nac_test_pyats_common/fmc/auth.py
@@ -1,0 +1,198 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2025 Daniel Schmidt
+
+# SPDX-License-Identifier: MPL-2.0
+
+"""FMC (Firepower Management Center) authentication implementation.
+
+This module provides token-based authentication for Cisco FMC's REST API.
+FMC uses HTTP Basic Auth to generate an access token, which is then used
+for subsequent API calls via the X-auth-access-token header.
+
+Authentication flow:
+    1. POST to /api/fmc_platform/v1/auth/generatetoken with Basic Auth
+    2. Extract X-auth-access-token and DOMAIN_UUID from response headers
+    3. Use access token in subsequent API requests
+
+Note on Fork Safety:
+    This module uses urllib (not httpx) for authentication requests.
+    httpx is NOT fork-safe on macOS — creating httpx.Client after fork() causes
+    silent crashes due to OpenSSL threading issues.
+"""
+
+import logging
+import os
+from typing import Any
+
+from nac_test.pyats_core.common.auth_cache import AuthCache
+from nac_test.pyats_core.common.subprocess_auth import (
+    SubprocessAuthError,  # noqa: F401 - re-exported for callers to catch
+    execute_auth_subprocess,
+)
+
+from nac_test_pyats_common.common.env import require_env_vars
+
+logger = logging.getLogger(__name__)
+
+FMC_TOKEN_LIFETIME_SECONDS: int = 1800
+
+AUTH_REQUEST_TIMEOUT_SECONDS: float = 30.0
+
+_AUTH_SCRIPT_BODY: str = """
+import base64
+import ssl
+import urllib.request
+
+url = params["url"]
+username = params["username"]
+password = params["password"]
+timeout = params["timeout"]
+verify_ssl = params["verify_ssl"]
+
+# Create SSL context
+ssl_context = ssl.create_default_context()
+if not verify_ssl:
+    ssl_context.check_hostname = False
+    ssl_context.verify_mode = ssl.CERT_NONE
+
+https_handler = urllib.request.HTTPSHandler(context=ssl_context)
+opener = urllib.request.build_opener(https_handler)
+
+# Build Basic Auth header
+credentials = base64.b64encode(f"{username}:{password}".encode()).decode()
+
+auth_request = urllib.request.Request(
+    f"{url}/api/fmc_platform/v1/auth/generatetoken",
+    headers={
+        "Authorization": f"Basic {credentials}",
+        "Content-Length": "0",
+    },
+    method="POST",
+)
+
+try:
+    auth_response = opener.open(auth_request, timeout=timeout)
+    access_token = auth_response.headers.get("X-auth-access-token")
+    domain_uuid = auth_response.headers.get("DOMAIN_UUID")
+
+    if not access_token:
+        result = {
+            "error": "No X-auth-access-token in response headers. "
+            "Verify FMC_USERNAME and FMC_PASSWORD are correct."
+        }
+    else:
+        result = {
+            "access_token": access_token,
+            "domain_uuid": domain_uuid or "",
+        }
+except urllib.error.HTTPError as e:
+    if e.code in (401, 403):
+        result = {
+            "error": (
+                f"Authentication failed - HTTP {e.code}: {e.reason}. "
+                "Verify FMC_USERNAME and FMC_PASSWORD are correct."
+            )
+        }
+    else:
+        error_body = e.read().decode("utf-8", errors="replace") if e.fp else ""
+        err_snippet = error_body[:200]
+        result = {
+            "error": (
+                f"Authentication request failed - HTTP {e.code}: {e.reason}. "
+                f"{err_snippet}"
+            ).strip()
+        }
+except Exception as e:
+    result = {
+        "error": f"Authentication request failed - network error: {e}"
+    }
+"""
+
+
+class FMCAuth:
+    """FMC authentication implementation.
+
+    Provides token-based authentication for Cisco Firepower Management Center.
+    Uses AuthCache for efficient token reuse across parallel test execution.
+
+    Example:
+        >>> auth_data = FMCAuth.get_auth()
+        >>> headers = {"X-auth-access-token": auth_data["access_token"]}
+        >>> domain_uuid = auth_data["domain_uuid"]
+    """
+
+    @staticmethod
+    def _authenticate(
+        url: str, username: str, password: str, verify_ssl: bool = False
+    ) -> tuple[dict[str, Any], int]:
+        """Perform FMC token generation via subprocess.
+
+        Args:
+            url: Base URL of FMC (e.g., "https://fmc.example.com").
+            username: FMC username.
+            password: FMC password.
+            verify_ssl: Whether to verify SSL certificates.
+
+        Returns:
+            Tuple of (auth_dict, expires_in_seconds).
+            auth_dict contains 'access_token' and 'domain_uuid'.
+
+        Raises:
+            SubprocessAuthError: If authentication subprocess fails.
+        """
+        auth_params = {
+            "url": url,
+            "username": username,
+            "password": password,
+            "timeout": AUTH_REQUEST_TIMEOUT_SECONDS,
+            "verify_ssl": verify_ssl,
+        }
+
+        auth_result = execute_auth_subprocess(auth_params, _AUTH_SCRIPT_BODY)
+
+        return {
+            "access_token": auth_result["access_token"],
+            "domain_uuid": auth_result.get("domain_uuid", ""),
+        }, FMC_TOKEN_LIFETIME_SECONDS
+
+    @classmethod
+    def get_auth(cls) -> dict[str, Any]:
+        """Get FMC authentication data with automatic caching and renewal.
+
+        Uses AuthCache to avoid redundant token generation across parallel
+        test processes.
+
+        Environment Variables Required:
+            FMC_URL: Base URL of the FMC
+            FMC_USERNAME: FMC username
+            FMC_PASSWORD: FMC password
+            FMC_INSECURE: If "True"/"1"/"yes", disable SSL verification
+                (default: disabled for lab compatibility)
+
+        Returns:
+            Dictionary containing:
+            - access_token (str): FMC API access token
+            - domain_uuid (str): FMC domain UUID for API path construction
+
+        Raises:
+            ValueError: If required environment variables are missing.
+            SubprocessAuthError: If authentication fails.
+        """
+        require_env_vars("FMC_URL", "FMC_USERNAME", "FMC_PASSWORD")
+
+        url = os.environ["FMC_URL"].rstrip("/")
+        username = os.environ["FMC_USERNAME"]
+        password = os.environ["FMC_PASSWORD"]
+
+        insecure_str = os.environ.get("FMC_INSECURE", "True").lower()
+        verify_ssl = insecure_str not in ("true", "1", "yes")
+
+        def auth_func() -> tuple[dict[str, Any], int]:
+            return cls._authenticate(url, username, password, verify_ssl)
+
+        result: dict[str, Any] = AuthCache.get_or_create(
+            controller_type="FMC",
+            url=url,
+            auth_func=auth_func,
+        )
+        return result

--- a/src/nac_test_pyats_common/fmc/device_resolver.py
+++ b/src/nac_test_pyats_common/fmc/device_resolver.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2025 Daniel Schmidt
+
+# SPDX-License-Identifier: MPL-2.0
+
+"""FTD device resolver for SSH/D2D testing.
+
+This module provides the FTDDeviceResolver class, which extends
+BaseDeviceResolver to navigate the FMC data model and extract
+FTD device information for SSH-based operational testing.
+
+Device Fields Returned:
+    - hostname: Device name from fmc.domains[].devices.devices[].name
+    - host: Management IP from fmc.domains[].devices.devices[].host
+    - os: Always 'fxos' (Firepower eXtensible OS)
+    - platform: Always 'ftd' (Firepower Threat Defense)
+    - username: From FTD_USERNAME environment variable
+    - password: From FTD_PASSWORD environment variable
+
+Note:
+    FTD SSH credentials are SEPARATE from FMC controller credentials.
+    FMC_USERNAME/FMC_PASSWORD are for the FMC REST API.
+    FTD_USERNAME/FTD_PASSWORD are for SSH access to FTD devices.
+"""
+
+import logging
+from typing import Any
+
+from nac_test_pyats_common.common import BaseDeviceResolver
+
+logger = logging.getLogger(__name__)
+
+
+class FTDDeviceResolver(BaseDeviceResolver):
+    """FTD device resolver for D2D testing.
+
+    Navigates the FMC NAC data model (fmc.domains[].devices.devices[])
+    to extract FTD device information for SSH testing. Devices are
+    flattened across all FMC domains into a single inventory.
+
+    Schema structure:
+        fmc:
+          domains:
+            - name: "Global"
+              devices:
+                devices:
+                  - name: "FTD-FW1"
+                    host: "10.1.1.100"
+                  - name: "FTD-FW2"
+                    host: "10.1.1.101"
+            - name: "Branch"
+              devices:
+                devices:
+                  - name: "FTD-BR1"
+                    host: "10.2.1.100"
+
+    Credentials:
+        Uses FTD_USERNAME and FTD_PASSWORD environment variables.
+        These are for SSH access to FTD devices, NOT for the FMC controller.
+
+    Example:
+        >>> resolver = FTDDeviceResolver(data_model)
+        >>> devices = resolver.get_resolved_inventory()
+        >>> devices[0]["hostname"]
+        'FTD-FW1'
+        >>> devices[0]["os"]
+        'fxos'
+        >>> devices[0]["platform"]
+        'ftd'
+    """
+
+    def get_architecture_name(self) -> str:
+        """Return the architecture identifier."""
+        return "fmc"
+
+    def get_schema_root_key(self) -> str:
+        """Return the top-level data model key."""
+        return "fmc"
+
+    def navigate_to_devices(self) -> list[dict[str, Any]]:
+        """Flatten all FTD devices across FMC domains.
+
+        Iterates fmc.domains[].devices.devices[] and collects all devices
+        into a single flat list regardless of which domain they belong to.
+        """
+        devices: list[dict[str, Any]] = []
+        fmc_data = self.data_model.get("fmc", {})
+        domains = fmc_data.get("domains", [])
+
+        for domain in domains:
+            domain_devices = domain.get("devices", {})
+            device_list = domain_devices.get("devices", [])
+            devices.extend(device_list)
+
+        return devices
+
+    def extract_hostname(self, device_data: dict[str, Any]) -> str:
+        """Extract device hostname from the name field."""
+        return str(device_data["name"])
+
+    def extract_host_ip(self, device_data: dict[str, Any]) -> str:
+        """Extract management IP from the host field.
+
+        The FMC data model stores the device's management IP/hostname
+        directly in the 'host' field (mapped from FMC API's hostName).
+        """
+        host = device_data.get("host")
+        if not host:
+            raise ValueError("Device has no 'host' field for management IP")
+        return str(host)
+
+    def extract_os_platform_type(self, device_data: dict[str, Any]) -> dict[str, str]:
+        """Return Unicon os and platform for FTD devices."""
+        return {"os": "fxos", "platform": "ftd"}
+
+    def get_credential_env_vars(self) -> tuple[str, str]:
+        """Return credential environment variable names."""
+        return ("FTD_USERNAME", "FTD_PASSWORD")

--- a/src/nac_test_pyats_common/fmc/ssh_test_base.py
+++ b/src/nac_test_pyats_common/fmc/ssh_test_base.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2025 Daniel Schmidt
+
+# SPDX-License-Identifier: MPL-2.0
+
+"""FTD-specific base test class for SSH/Direct-to-Device testing.
+
+This module provides the FTDTestBase class, which extends the generic SSHTestBase
+to add FTD-specific functionality for device-to-device (D2D) testing.
+
+The class delegates device inventory resolution to FTDDeviceResolver, which
+handles FMC data model navigation and credential injection.
+
+Credentials:
+    FTD D2D tests connect to Firepower Threat Defense devices, NOT the FMC
+    controller. Set these environment variables:
+    - FTD_USERNAME: SSH username for FTD devices
+    - FTD_PASSWORD: SSH password for FTD devices
+
+PyATS/Unicon Configuration:
+    FTD devices use os='fxos' and platform='ftd', which activates the
+    Unicon FTD plugin with its multi-state CLI (chassis, fxos, ftd_console,
+    ftd_expert). The plugin handles state transitions automatically.
+"""
+
+import logging
+from typing import Any
+
+from nac_test.pyats_core.common.ssh_base_test import (
+    SSHTestBase,  # type: ignore[import-untyped]
+)
+
+from .device_resolver import FTDDeviceResolver
+
+logger = logging.getLogger(__name__)
+
+
+class FTDTestBase(SSHTestBase):  # type: ignore[misc]
+    """FTD-specific base test class for SSH/D2D testing.
+
+    This class extends SSHTestBase and implements the contract required by
+    nac-test's SSH execution engine. Device inventory resolution is fully
+    delegated to FTDDeviceResolver.
+
+    Credentials:
+        FTD D2D tests require FTD_USERNAME and FTD_PASSWORD environment
+        variables (NOT FMC_* which are for the controller API).
+
+    Example:
+        class MyFTDTest(FTDTestBase):
+            @aetest.test
+            def verify_failover_status(self, steps, device):
+                # SSH-based verification on FTD device
+                output = device.execute("show failover")
+                # process output...
+    """
+
+    _last_resolver: "FTDDeviceResolver | None" = None
+
+    @classmethod
+    def get_ssh_device_inventory(
+        cls, data_model: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        """Parse the FMC data model to retrieve FTD device inventory.
+
+        This method is the entry point called by nac-test's orchestrator.
+        All device inventory resolution is delegated to FTDDeviceResolver,
+        which handles:
+        - Schema navigation (fmc.domains[].devices.devices[])
+        - Flattening devices across all FMC domains
+        - Credential injection (FTD_USERNAME, FTD_PASSWORD)
+
+        After calling this method, access cls._last_resolver.skipped_devices
+        to get information about devices that failed resolution.
+
+        Args:
+            data_model: The merged data model from nac-test containing all
+                FMC configuration data with resolved variables.
+
+        Returns:
+            List of device dictionaries, each containing:
+            - hostname (str): FTD device name
+            - host (str): Management IP address for SSH connection
+            - os (str): Always "fxos"
+            - platform (str): Always "ftd"
+            - username (str): Environment variable reference
+            - password (str): Environment variable reference
+        """
+        resolver = FTDDeviceResolver(data_model)
+        cls._last_resolver = resolver
+        return resolver.get_resolved_inventory()

--- a/tests/unit/fmc/__init__.py
+++ b/tests/unit/fmc/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2025 Daniel Schmidt
+
+# SPDX-License-Identifier: MPL-2.0

--- a/tests/unit/fmc/test_auth.py
+++ b/tests/unit/fmc/test_auth.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2025 Daniel Schmidt
+
+# SPDX-License-Identifier: MPL-2.0
+
+"""Unit tests for FMCAuth."""
+
+import ast
+
+import pytest
+from pytest_mock import MockerFixture
+
+from nac_test_pyats_common.fmc.auth import (
+    _AUTH_SCRIPT_BODY,
+    FMC_TOKEN_LIFETIME_SECONDS,
+    FMCAuth,
+)
+
+
+class TestAuthScriptBody:
+    """Test that the auth script body is valid Python."""
+
+    def test_script_compiles(self) -> None:
+        """Auth script body must be syntactically valid Python."""
+        ast.parse(_AUTH_SCRIPT_BODY)
+
+    def test_script_uses_params_dict(self) -> None:
+        """Auth script body should reference expected params keys."""
+        assert "params[" in _AUTH_SCRIPT_BODY
+        assert '"url"' in _AUTH_SCRIPT_BODY
+        assert '"username"' in _AUTH_SCRIPT_BODY
+        assert '"password"' in _AUTH_SCRIPT_BODY
+
+    def test_script_sets_result(self) -> None:
+        """Auth script body must set a result dict."""
+        assert "result" in _AUTH_SCRIPT_BODY
+        assert "access_token" in _AUTH_SCRIPT_BODY
+        assert "domain_uuid" in _AUTH_SCRIPT_BODY
+
+
+class TestFMCAuthAuthenticate:
+    """Test the _authenticate static method."""
+
+    def test_authenticate_returns_tuple(self, mocker: MockerFixture) -> None:
+        """_authenticate should return (auth_dict, ttl) tuple."""
+        mock_subprocess = mocker.patch(
+            "nac_test_pyats_common.fmc.auth.execute_auth_subprocess",
+            return_value={
+                "access_token": "test-token-abc",
+                "domain_uuid": "e276abec-e0f2-11e3-8169-6d9ed49b625f",
+            },
+        )
+
+        auth_data, ttl = FMCAuth._authenticate(
+            "https://fmc.example.com", "admin", "password"
+        )
+
+        assert auth_data["access_token"] == "test-token-abc"
+        assert auth_data["domain_uuid"] == "e276abec-e0f2-11e3-8169-6d9ed49b625f"
+        assert ttl == FMC_TOKEN_LIFETIME_SECONDS
+        mock_subprocess.assert_called_once()
+
+    def test_authenticate_missing_domain_uuid(self, mocker: MockerFixture) -> None:
+        """_authenticate handles missing domain_uuid gracefully."""
+        mocker.patch(
+            "nac_test_pyats_common.fmc.auth.execute_auth_subprocess",
+            return_value={"access_token": "test-token"},
+        )
+
+        auth_data, _ = FMCAuth._authenticate(
+            "https://fmc.example.com", "admin", "password"
+        )
+
+        assert auth_data["access_token"] == "test-token"
+        assert auth_data["domain_uuid"] == ""
+
+
+class TestFMCAuthGetAuth:
+    """Test the get_auth class method."""
+
+    def test_get_auth_with_env_vars(
+        self, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture
+    ) -> None:
+        """get_auth should use env vars and return cached auth data."""
+        monkeypatch.setenv("FMC_URL", "https://fmc.lab.local")
+        monkeypatch.setenv("FMC_USERNAME", "admin")
+        monkeypatch.setenv("FMC_PASSWORD", "C1sco12345")
+
+        expected_data = {
+            "access_token": "cached-token",
+            "domain_uuid": "domain-123",
+        }
+        mocker.patch(
+            "nac_test_pyats_common.fmc.auth.AuthCache.get_or_create",
+            return_value=expected_data,
+        )
+
+        result = FMCAuth.get_auth()
+
+        assert result == expected_data
+
+    def test_get_auth_missing_env_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """get_auth should raise when required env vars are missing."""
+        monkeypatch.delenv("FMC_URL", raising=False)
+        monkeypatch.delenv("FMC_USERNAME", raising=False)
+        monkeypatch.delenv("FMC_PASSWORD", raising=False)
+
+        with pytest.raises(ValueError, match="FMC_URL"):
+            FMCAuth.get_auth()
+
+    def test_get_auth_strips_trailing_slash(
+        self, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture
+    ) -> None:
+        """get_auth should strip trailing slash from FMC_URL."""
+        monkeypatch.setenv("FMC_URL", "https://fmc.lab.local/")
+        monkeypatch.setenv("FMC_USERNAME", "admin")
+        monkeypatch.setenv("FMC_PASSWORD", "pass")
+
+        mock_cache = mocker.patch(
+            "nac_test_pyats_common.fmc.auth.AuthCache.get_or_create",
+            return_value={"access_token": "t", "domain_uuid": "d"},
+        )
+
+        FMCAuth.get_auth()
+
+        call_kwargs = mock_cache.call_args[1]
+        assert call_kwargs["url"] == "https://fmc.lab.local"
+
+    def test_get_auth_ssl_verify_default_disabled(
+        self, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture
+    ) -> None:
+        """By default, FMC_INSECURE=True so verify_ssl=False."""
+        monkeypatch.setenv("FMC_URL", "https://fmc.lab.local")
+        monkeypatch.setenv("FMC_USERNAME", "admin")
+        monkeypatch.setenv("FMC_PASSWORD", "pass")
+        monkeypatch.delenv("FMC_INSECURE", raising=False)
+
+        mock_authenticate = mocker.patch.object(
+            FMCAuth,
+            "_authenticate",
+            return_value=({"access_token": "t", "domain_uuid": "d"}, 1800),
+        )
+        mocker.patch(
+            "nac_test_pyats_common.fmc.auth.AuthCache.get_or_create",
+            side_effect=lambda controller_type, url, auth_func: auth_func(),
+        )
+
+        FMCAuth.get_auth()
+
+        mock_authenticate.assert_called_once_with(
+            "https://fmc.lab.local", "admin", "pass", False
+        )

--- a/tests/unit/fmc/test_device_resolver.py
+++ b/tests/unit/fmc/test_device_resolver.py
@@ -1,0 +1,227 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2025 Daniel Schmidt
+
+# SPDX-License-Identifier: MPL-2.0
+
+"""Unit tests for FTDDeviceResolver."""
+
+from typing import Any
+
+import pytest
+
+from nac_test_pyats_common.fmc.device_resolver import FTDDeviceResolver
+
+
+@pytest.fixture
+def sample_data_model() -> dict[str, Any]:
+    """FMC data model with devices across multiple domains."""
+    return {
+        "fmc": {
+            "domains": [
+                {
+                    "name": "Global",
+                    "devices": {
+                        "devices": [
+                            {"name": "FTD-DC-FW1", "host": "10.1.1.100"},
+                            {"name": "FTD-DC-FW2", "host": "10.1.1.101"},
+                        ]
+                    },
+                },
+                {
+                    "name": "Branch",
+                    "devices": {
+                        "devices": [
+                            {"name": "FTD-BR-FW1", "host": "10.2.1.100"},
+                        ]
+                    },
+                },
+            ]
+        }
+    }
+
+
+@pytest.fixture
+def single_domain_data_model() -> dict[str, Any]:
+    """FMC data model with a single domain."""
+    return {
+        "fmc": {
+            "domains": [
+                {
+                    "name": "Global",
+                    "devices": {
+                        "devices": [
+                            {"name": "M1-FPR4215-1", "host": "9.1.29.50"},
+                            {"name": "M1-FPR4215-2", "host": "9.1.29.51"},
+                        ]
+                    },
+                }
+            ]
+        }
+    }
+
+
+@pytest.fixture
+def empty_data_model() -> dict[str, Any]:
+    """Data model with no FMC data."""
+    return {}
+
+
+class TestFTDDeviceResolverNavigation:
+    """Test schema navigation and device flattening."""
+
+    def test_navigate_flattens_across_domains(
+        self, sample_data_model: dict[str, Any]
+    ) -> None:
+        """Navigate flattens across domains."""
+        resolver = FTDDeviceResolver(sample_data_model)
+        devices = resolver.navigate_to_devices()
+        assert len(devices) == 3
+        assert devices[0]["name"] == "FTD-DC-FW1"
+        assert devices[1]["name"] == "FTD-DC-FW2"
+        assert devices[2]["name"] == "FTD-BR-FW1"
+
+    def test_navigate_single_domain(
+        self, single_domain_data_model: dict[str, Any]
+    ) -> None:
+        """Navigate single domain."""
+        resolver = FTDDeviceResolver(single_domain_data_model)
+        devices = resolver.navigate_to_devices()
+        assert len(devices) == 2
+
+    def test_navigate_missing_fmc_key(self, empty_data_model: dict[str, Any]) -> None:
+        """Navigate missing fmc key."""
+        resolver = FTDDeviceResolver(empty_data_model)
+        devices = resolver.navigate_to_devices()
+        assert devices == []
+
+    def test_navigate_empty_domains(self) -> None:
+        """Navigate empty domains."""
+        resolver = FTDDeviceResolver({"fmc": {"domains": []}})
+        devices = resolver.navigate_to_devices()
+        assert devices == []
+
+    def test_navigate_domain_missing_devices_key(self) -> None:
+        """Navigate domain missing devices key."""
+        resolver = FTDDeviceResolver({"fmc": {"domains": [{"name": "Global"}]}})
+        devices = resolver.navigate_to_devices()
+        assert devices == []
+
+    def test_navigate_domain_empty_device_list(self) -> None:
+        """Navigate domain empty device list."""
+        resolver = FTDDeviceResolver(
+            {"fmc": {"domains": [{"name": "Global", "devices": {"devices": []}}]}}
+        )
+        devices = resolver.navigate_to_devices()
+        assert devices == []
+
+
+class TestFTDDeviceResolverExtraction:
+    """Test field extraction from device data."""
+
+    def test_extract_hostname(self, sample_data_model: dict[str, Any]) -> None:
+        """Extract hostname."""
+        resolver = FTDDeviceResolver(sample_data_model)
+        device = {"name": "FTD-DC-FW1", "host": "10.1.1.100"}
+        assert resolver.extract_hostname(device) == "FTD-DC-FW1"
+
+    def test_extract_host_ip(self, sample_data_model: dict[str, Any]) -> None:
+        """Extract host ip."""
+        resolver = FTDDeviceResolver(sample_data_model)
+        device = {"name": "FTD-DC-FW1", "host": "10.1.1.100"}
+        assert resolver.extract_host_ip(device) == "10.1.1.100"
+
+    def test_extract_host_ip_missing_raises(
+        self, sample_data_model: dict[str, Any]
+    ) -> None:
+        """Extract host ip missing raises."""
+        resolver = FTDDeviceResolver(sample_data_model)
+        device = {"name": "FTD-NO-HOST"}
+        with pytest.raises(ValueError, match="no 'host' field"):
+            resolver.extract_host_ip(device)
+
+    def test_extract_host_ip_empty_raises(
+        self, sample_data_model: dict[str, Any]
+    ) -> None:
+        """Extract host ip empty raises."""
+        resolver = FTDDeviceResolver(sample_data_model)
+        device = {"name": "FTD-EMPTY", "host": ""}
+        with pytest.raises(ValueError, match="no 'host' field"):
+            resolver.extract_host_ip(device)
+
+    def test_extract_os_platform_type(self, sample_data_model: dict[str, Any]) -> None:
+        """Extract os platform type."""
+        resolver = FTDDeviceResolver(sample_data_model)
+        device = {"name": "FTD-DC-FW1", "host": "10.1.1.100"}
+        result = resolver.extract_os_platform_type(device)
+        assert result == {"os": "fxos", "platform": "ftd"}
+
+    def test_get_architecture_name(self, sample_data_model: dict[str, Any]) -> None:
+        """Get architecture name."""
+        resolver = FTDDeviceResolver(sample_data_model)
+        assert resolver.get_architecture_name() == "fmc"
+
+    def test_get_schema_root_key(self, sample_data_model: dict[str, Any]) -> None:
+        """Get schema root key."""
+        resolver = FTDDeviceResolver(sample_data_model)
+        assert resolver.get_schema_root_key() == "fmc"
+
+    def test_get_credential_env_vars(self, sample_data_model: dict[str, Any]) -> None:
+        """Get credential env vars."""
+        resolver = FTDDeviceResolver(sample_data_model)
+        assert resolver.get_credential_env_vars() == ("FTD_USERNAME", "FTD_PASSWORD")
+
+
+class TestFTDDeviceResolverCredentials:
+    """Test credential injection."""
+
+    def test_credentials_injected(
+        self, single_domain_data_model: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Credentials injected."""
+        monkeypatch.setenv("FTD_USERNAME", "admin")
+        monkeypatch.setenv("FTD_PASSWORD", "C1sco12345")
+
+        resolver = FTDDeviceResolver(single_domain_data_model)
+        devices = resolver.get_resolved_inventory()
+
+        for device in devices:
+            assert device["username"] == "%ENV{FTD_USERNAME}"
+            assert device["password"] == "%ENV{FTD_PASSWORD}"
+
+    def test_missing_credentials_raises(
+        self, single_domain_data_model: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Missing credentials raises."""
+        monkeypatch.delenv("FTD_USERNAME", raising=False)
+        monkeypatch.delenv("FTD_PASSWORD", raising=False)
+
+        resolver = FTDDeviceResolver(single_domain_data_model)
+        with pytest.raises(ValueError, match="Missing required credential"):
+            resolver.get_resolved_inventory()
+
+
+class TestFTDDeviceResolverFullInventory:
+    """Test full inventory resolution end-to-end."""
+
+    def test_full_resolution_multi_domain(
+        self, sample_data_model: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Full resolution multi domain."""
+        monkeypatch.setenv("FTD_USERNAME", "admin")
+        monkeypatch.setenv("FTD_PASSWORD", "password")
+
+        resolver = FTDDeviceResolver(sample_data_model)
+        devices = resolver.get_resolved_inventory()
+
+        assert len(devices) == 3
+
+        assert devices[0]["hostname"] == "FTD-DC-FW1"
+        assert devices[0]["host"] == "10.1.1.100"
+        assert devices[0]["os"] == "fxos"
+        assert devices[0]["platform"] == "ftd"
+
+        assert devices[1]["hostname"] == "FTD-DC-FW2"
+        assert devices[1]["host"] == "10.1.1.101"
+
+        assert devices[2]["hostname"] == "FTD-BR-FW1"
+        assert devices[2]["host"] == "10.2.1.100"


### PR DESCRIPTION
## Summary

- Adds FMC REST API adapter (`FMCAuth` + `FMCTestBase`) for operational testing against Cisco Firepower Management Center
- Includes FTD SSH adapter as prerequisite (FTD devices are managed by FMC)

## Status: Draft

**This PR is a draft because the FMC API adapter has NOT been tested against a live FMC controller.** Unit tests cover the auth flow and token caching logic, but end-to-end validation is pending.

The FTD SSH adapter included here IS fully tested (see PR #43).

## New Components (beyond PR #43)

| File | Purpose |
|------|---------|
| `src/nac_test_pyats_common/fmc/auth.py` | `FMCAuth` — token-based auth with `AuthCache` integration |
| `src/nac_test_pyats_common/fmc/api_test_base.py` | `FMCTestBase` — base class for FMC REST API tests |
| `tests/unit/fmc/test_auth.py` | Unit tests for FMCAuth (153 lines) |

## Design

- Token auth via `FMC_URL`, `FMC_USERNAME`, `FMC_PASSWORD` env vars
- Integrates with existing `AuthCache` for token reuse across tests
- `FMCTestBase` provides httpx client with auth headers for API calls

## Test plan

- [x] Unit tests pass (26 tests total — auth + device resolver)
- [ ] End-to-end validation against live FMC controller (pending)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: claude-opus-4-6
- **AI Contribution**: ~80%
- **AI Reason**: adapter scaffolding + unit tests
- **Human Oversight**: Code reviewed by Christopher Hart; not yet validated against live FMC